### PR TITLE
現在地から周辺の店舗情報を取得する機能追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,15 +60,9 @@
       }
     },
     "node_modules/@adobe/css-tools": {
-<<<<<<< HEAD
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.2.tgz",
-      "integrity": "sha512-baYZExFpsdkBNuvGKTKWCwKH57HRZLVtycZS05WTQNVOiXVSeAki3nU35zlRbToeMW8aHlJfyS+1C4BOv27q0A==",
-=======
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT"
     },
@@ -85,58 +79,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-<<<<<<< HEAD
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@babel/code-frame": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.9",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
-=======
-    "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/compat-data": {
-<<<<<<< HEAD
-      "version": "7.26.8",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.8.tgz",
-      "integrity": "sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==",
-=======
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
-      "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -144,41 +105,22 @@
       }
     },
     "node_modules/@babel/core": {
-<<<<<<< HEAD
-      "version": "7.26.10",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
-      "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.10",
-        "@babel/helper-compilation-targets": "^7.26.5",
-        "@babel/helper-module-transforms": "^7.26.0",
-        "@babel/helpers": "^7.26.10",
-        "@babel/parser": "^7.26.10",
-        "@babel/template": "^7.26.9",
-        "@babel/traverse": "^7.26.10",
-        "@babel/types": "^7.26.10",
-=======
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
-      "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.4",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
         "@jridgewell/remapping": "^2.3.5",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -204,29 +146,16 @@
       }
     },
     "node_modules/@babel/generator": {
-<<<<<<< HEAD
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.0.tgz",
-      "integrity": "sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.0",
-        "@babel/types": "^7.27.0",
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25",
-=======
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
-      "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         "jsesc": "^3.0.2"
       },
       "engines": {
@@ -234,25 +163,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-<<<<<<< HEAD
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.0.tgz",
-      "integrity": "sha512-LVk7fbXml0H2xH34dFzKQ7TDZ2G4/rVTOrq9V+icbbadjbVxxeFeDsNHv2SrZeWoA+6ZiTyWYWtScEIW07EAcA==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.26.8",
-        "@babel/helper-validator-option": "^7.25.9",
-=======
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.27.2",
+        "@babel/compat-data": "^7.28.6",
         "@babel/helper-validator-option": "^7.27.1",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -271,17 +189,6 @@
         "semver": "bin/semver.js"
       }
     },
-<<<<<<< HEAD
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
-      "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.25.9",
-        "@babel/types": "^7.25.9"
-=======
     "node_modules/@babel/helper-globals": {
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
@@ -293,42 +200,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-<<<<<<< HEAD
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
-      "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9",
-        "@babel/traverse": "^7.25.9"
-=======
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -338,15 +232,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-<<<<<<< HEAD
-      "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
-      "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
-=======
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -354,15 +242,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-<<<<<<< HEAD
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
-=======
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -370,15 +252,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-<<<<<<< HEAD
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
-=======
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -386,15 +262,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-<<<<<<< HEAD
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
-      "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
-=======
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -402,48 +272,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-<<<<<<< HEAD
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
-      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
+      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.0",
-        "@babel/types": "^7.27.0"
-=======
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-<<<<<<< HEAD
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
-      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.0"
-=======
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.28.5"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -508,23 +357,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
-<<<<<<< HEAD
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
-      "integrity": "sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
-=======
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
-      "integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -560,23 +399,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-<<<<<<< HEAD
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.9.tgz",
-      "integrity": "sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
-=======
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
-      "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -696,23 +525,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-<<<<<<< HEAD
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.9.tgz",
-      "integrity": "sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
-=======
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
-      "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -722,117 +541,57 @@
       }
     },
     "node_modules/@babel/runtime": {
-<<<<<<< HEAD
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
-      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
       "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-=======
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
-      "license": "MIT",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
-<<<<<<< HEAD
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
-      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.27.0",
-        "@babel/types": "^7.27.0"
-=======
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-<<<<<<< HEAD
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.0.tgz",
-      "integrity": "sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.27.0",
-        "@babel/parser": "^7.27.0",
-        "@babel/template": "^7.27.0",
-        "@babel/types": "^7.27.0",
-        "debug": "^4.3.1",
-        "globals": "^11.1.0"
-=======
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
-      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
         "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
         "debug": "^4.3.1"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-<<<<<<< HEAD
-    "node_modules/@babel/traverse/node_modules/globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@babel/types": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
-      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9"
-=======
-    "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.28.5"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       },
       "engines": {
         "node": ">=6.9.0"
@@ -846,37 +605,21 @@
       "license": "MIT"
     },
     "node_modules/@emnapi/core": {
-<<<<<<< HEAD
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.3.tgz",
-      "integrity": "sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==",
-=======
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.7.1.tgz",
-      "integrity": "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
+      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-<<<<<<< HEAD
-        "@emnapi/wasi-threads": "1.0.2",
-=======
         "@emnapi/wasi-threads": "1.1.0",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-<<<<<<< HEAD
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.3.tgz",
-      "integrity": "sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==",
-=======
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
-      "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -885,15 +628,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-<<<<<<< HEAD
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.2.tgz",
-      "integrity": "sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==",
-=======
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
       "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -963,442 +700,10 @@
       "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
       "license": "MIT"
     },
-<<<<<<< HEAD
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.3.tgz",
-      "integrity": "sha512-W8bFfPA8DowP8l//sxjJLSLkD8iEjMc7cBVyP+u4cEv9sM7mdUCkgsj+t0n/BWPFtv7WWCN5Yzj0N6FJNUUqBQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.3.tgz",
-      "integrity": "sha512-PuwVXbnP87Tcff5I9ngV0lmiSu40xw1At6i3GsU77U7cjDDB4s0X2cyFuBiDa1SBk9DnvWwnGvVaGBqoFWPb7A==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.3.tgz",
-      "integrity": "sha512-XelR6MzjlZuBM4f5z2IQHK6LkK34Cvv6Rj2EntER3lwCBFdg6h2lKbtRjpTTsdEjD/WSe1q8UyPBXP1x3i/wYQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.3.tgz",
-      "integrity": "sha512-ogtTpYHT/g1GWS/zKM0cc/tIebFjm1F9Aw1boQ2Y0eUQ+J89d0jFY//s9ei9jVIlkYi8AfOjiixcLJSGNSOAdQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.3.tgz",
-      "integrity": "sha512-eESK5yfPNTqpAmDfFWNsOhmIOaQA59tAcF/EfYvo5/QWQCzXn5iUSOnqt3ra3UdzBv073ykTtmeLJZGt3HhA+w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.3.tgz",
-      "integrity": "sha512-Kd8glo7sIZtwOLcPbW0yLpKmBNWMANZhrC1r6K++uDR2zyzb6AeOYtI6udbtabmQpFaxJ8uduXMAo1gs5ozz8A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.3.tgz",
-      "integrity": "sha512-EJiyS70BYybOBpJth3M0KLOus0n+RRMKTYzhYhFeMwp7e/RaajXvP+BWlmEXNk6uk+KAu46j/kaQzr6au+JcIw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.3.tgz",
-      "integrity": "sha512-Q+wSjaLpGxYf7zC0kL0nDlhsfuFkoN+EXrx2KSB33RhinWzejOd6AvgmP5JbkgXKmjhmpfgKZq24pneodYqE8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.3.tgz",
-      "integrity": "sha512-dUOVmAUzuHy2ZOKIHIKHCm58HKzFqd+puLaS424h6I85GlSDRZIA5ycBixb3mFgM0Jdh+ZOSB6KptX30DD8YOQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.3.tgz",
-      "integrity": "sha512-xCUgnNYhRD5bb1C1nqrDV1PfkwgbswTTBRbAd8aH5PhYzikdf/ddtsYyMXFfGSsb/6t6QaPSzxtbfAZr9uox4A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.3.tgz",
-      "integrity": "sha512-yplPOpczHOO4jTYKmuYuANI3WhvIPSVANGcNUeMlxH4twz/TeXuzEP41tGKNGWJjuMhotpGabeFYGAOU2ummBw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.3.tgz",
-      "integrity": "sha512-P4BLP5/fjyihmXCELRGrLd793q/lBtKMQl8ARGpDxgzgIKJDRJ/u4r1A/HgpBpKpKZelGct2PGI4T+axcedf6g==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.3.tgz",
-      "integrity": "sha512-eRAOV2ODpu6P5divMEMa26RRqb2yUoYsuQQOuFUexUoQndm4MdpXXDBbUoKIc0iPa4aCO7gIhtnYomkn2x+bag==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.3.tgz",
-      "integrity": "sha512-ZC4jV2p7VbzTlnl8nZKLcBkfzIf4Yad1SJM4ZMKYnJqZFD4rTI+pBG65u8ev4jk3/MPwY9DvGn50wi3uhdaghg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.3.tgz",
-      "integrity": "sha512-LDDODcFzNtECTrUUbVCs6j9/bDVqy7DDRsuIXJg6so+mFksgwG7ZVnTruYi5V+z3eE5y+BJZw7VvUadkbfg7QA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.3.tgz",
-      "integrity": "sha512-s+w/NOY2k0yC2p9SLen+ymflgcpRkvwwa02fqmAwhBRI3SC12uiS10edHHXlVWwfAagYSY5UpmT/zISXPMW3tQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.3.tgz",
-      "integrity": "sha512-nQHDz4pXjSDC6UfOE1Fw9Q8d6GCAd9KdvMZpfVGWSJztYCarRgSDfOVBY5xwhQXseiyxapkiSJi/5/ja8mRFFA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.3.tgz",
-      "integrity": "sha512-1QaLtOWq0mzK6tzzp0jRN3eccmN3hezey7mhLnzC6oNlJoUJz4nym5ZD7mDnS/LZQgkrhEbEiTn515lPeLpgWA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.3.tgz",
-      "integrity": "sha512-i5Hm68HXHdgv8wkrt+10Bc50zM0/eonPb/a/OFVfB6Qvpiirco5gBA5bz7S2SHuU+Y4LWn/zehzNX14Sp4r27g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.3.tgz",
-      "integrity": "sha512-zGAVApJEYTbOC6H/3QBr2mq3upG/LBEXr85/pTtKiv2IXcgKV0RT0QA/hSXZqSvLEpXeIxah7LczB4lkiYhTAQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.3.tgz",
-      "integrity": "sha512-fpqctI45NnCIDKBH5AXQBsD0NDPbEFczK98hk/aa6HJxbl+UtLkJV2+Bvy5hLSLk3LHmqt0NTkKNso1A9y1a4w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.3.tgz",
-      "integrity": "sha512-ROJhm7d8bk9dMCUZjkS8fgzsPAZEjtRJqCAmVgB0gMrvG7hfmPmz9k1rwO4jSiblFjYmNvbECL9uhaPzONMfgA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.3.tgz",
-      "integrity": "sha512-YWcow8peiHpNBiIXHwaswPnAXLsLVygFwCB3A7Bh5jRkIBFWHGmNQ48AlX4xDvQNoMZlPYzjVOQDYEzWCqufMQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.3.tgz",
-      "integrity": "sha512-qspTZOIGoXVS4DpNqUYUs9UxVb04khS1Degaw/MnfMe7goQ3lTfQ13Vw4qY/Nj0979BGvMRpAYbs/BAxEvU8ew==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.3.tgz",
-      "integrity": "sha512-ICgUR+kPimx0vvRzf+N/7L7tVSQeE3BYY+NhHRHXS1kBuPO7z2+7ea2HbhDyZdTephgvNvKrlDDKUexuCVBVvg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.6.1.tgz",
-      "integrity": "sha512-KTsJMmobmbrFLe3LDh0PC2FXpcSYJt/MLjlkh/9LEnmKYLSYmT/0EW9JWANjeoemiuZrmogti0tW5Ch+qNUYDw==",
-=======
-    "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1415,15 +720,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-<<<<<<< HEAD
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
-=======
       "version": "4.12.2",
       "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
       "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1465,59 +764,31 @@
       }
     },
     "node_modules/@floating-ui/core": {
-<<<<<<< HEAD
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
-      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/utils": "^0.2.9"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
-      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.9"
-      }
-    },
-    "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
-      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.0.0"
-=======
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
-      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/utils": "^0.2.10"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
       "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
-      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
+      "integrity": "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
+      "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.4",
         "@floating-ui/utils": "^0.2.10"
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
-      "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.7.tgz",
+      "integrity": "sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.7.4"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+        "@floating-ui/dom": "^1.7.5"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -1525,15 +796,9 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-<<<<<<< HEAD
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
-      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
-=======
       "version": "0.2.10",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "license": "MIT"
     },
     "node_modules/@googlemaps/js-api-loader": {
@@ -1609,15 +874,9 @@
       }
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-<<<<<<< HEAD
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-=======
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1628,15 +887,9 @@
       }
     },
     "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-<<<<<<< HEAD
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-=======
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1691,15 +944,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-<<<<<<< HEAD
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-=======
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
       "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1998,7 +1245,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2122,20 +1369,6 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-<<<<<<< HEAD
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-=======
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
@@ -2155,7 +1388,6 @@
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -2168,40 +1400,17 @@
         "node": ">=6.0.0"
       }
     },
-<<<<<<< HEAD
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-=======
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-<<<<<<< HEAD
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-=======
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2213,7 +1422,7 @@
       "version": "5.0.0-beta.42",
       "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.42.tgz",
       "integrity": "sha512-fWRiUJVCHCPF+mxd5drn08bY2qRw3jj5f1SSQdUXmaJ/yKpk23ys8MgLO2KGVTRtbks/+ctRfgffGPbXifj0Ug==",
-      "deprecated": "This package has been replaced by @base-ui-components/react",
+      "deprecated": "This package has been replaced by @base-ui/react",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.24.4",
@@ -2252,15 +1461,9 @@
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
-<<<<<<< HEAD
-      "version": "6.4.11",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-6.4.11.tgz",
-      "integrity": "sha512-CzAQs9CTzlwbsF9ZYB4o4lLwBv1/qNE264NjuYao+ctAXsmlPtYa8RtER4UsUXSMxNN9Qi+aQdYcKl2sUpnmAw==",
-=======
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-6.5.0.tgz",
       "integrity": "sha512-LGb8t8i6M2ZtS3Drn3GbTI1DVhDY6FJ9crEey2lZ0aN2EMZo8IZBZj9wRf4vqbZHaWjsYgtbOnJw5V8UWbmK2Q==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -2318,16 +1521,6 @@
       }
     },
     "node_modules/@mui/material": {
-<<<<<<< HEAD
-      "version": "6.4.11",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.4.11.tgz",
-      "integrity": "sha512-k2D3FLJS+/qD0qnd6ZlAjGFvaaxe1Dl10NyvpeDzIebMuYdn8VqYe6XBgGueEAtnzSJM4V03VD9kb5Fi24dnTA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@mui/core-downloads-tracker": "^6.4.11",
-        "@mui/system": "^6.4.11",
-=======
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.5.0.tgz",
       "integrity": "sha512-yjvtXoFcrPLGtgKRxFaH6OQPtcLPhkloC0BML6rBG5UeldR0nPULR/2E2BfXdo5JNV7j7lOzrrLX2Qf/iSidow==",
@@ -2337,7 +1530,6 @@
         "@babel/runtime": "^7.26.0",
         "@mui/core-downloads-tracker": "^6.5.0",
         "@mui/system": "^6.5.0",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         "@mui/types": "~7.2.24",
         "@mui/utils": "^6.4.9",
         "@popperjs/core": "^2.11.8",
@@ -2358,11 +1550,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-<<<<<<< HEAD
-        "@mui/material-pigment-css": "^6.4.11",
-=======
         "@mui/material-pigment-css": "^6.5.0",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -2433,15 +1621,9 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-<<<<<<< HEAD
-      "version": "6.4.11",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-6.4.11.tgz",
-      "integrity": "sha512-74AUmlHXaGNbyUqdK/+NwDJOZqgRQw6BcNvhoWYLq3LGbLTkE+khaJ7soz6cIabE4CPYqO2/QAIU1Z/HEjjpcw==",
-=======
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-6.5.0.tgz",
       "integrity": "sha512-8woC2zAqF4qUDSPIBZ8v3sakj+WgweolpyM/FXf8jAx6FMls+IE4Y8VDZc+zS805J7PRz31vz73n2SovKGaYgw==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
@@ -2473,24 +1655,14 @@
       }
     },
     "node_modules/@mui/system": {
-<<<<<<< HEAD
-      "version": "6.4.11",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-6.4.11.tgz",
-      "integrity": "sha512-gibtsrZEwnDaT5+I/KloOj/yHluX5G8heknuxBpQOdEQ3Gc0avjSImn5hSeKp8D4thiwZiApuggIjZw1dQguUA==",
-=======
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@mui/system/-/system-6.5.0.tgz",
       "integrity": "sha512-XcbBYxDS+h/lgsoGe78ExXFZXtuIlSBpn/KsZq8PtZcIkUNJInkuDqcLd2rVBQrDC1u+rvVovdaWPf2FHKJf3w==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@mui/private-theming": "^6.4.9",
-<<<<<<< HEAD
-        "@mui/styled-engine": "^6.4.11",
-=======
         "@mui/styled-engine": "^6.5.0",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         "@mui/types": "~7.2.24",
         "@mui/utils": "^6.4.9",
         "clsx": "^2.1.1",
@@ -2546,21 +1718,12 @@
       }
     },
     "node_modules/@mui/types": {
-<<<<<<< HEAD
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.1.tgz",
-      "integrity": "sha512-gUL8IIAI52CRXP/MixT1tJKt3SI6tVv4U/9soFsTtAsHzaJQptZ42ffdHZV3niX1ei0aUgMvOxBBN0KYqdG39g==",
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.11.tgz",
+      "integrity": "sha512-fZ2xO9D08IKOxO2oUBi1nnVKH6oJUD+64cnv4YAaFoC0E5+i1+S5AHbNqqvZlYYsbPEQ6qEVwuBqY3jl5W4G+Q==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.27.0"
-=======
-      "version": "7.4.9",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.9.tgz",
-      "integrity": "sha512-dNO8Z9T2cujkSIaCnWwprfeKmTWh97cnjkgmpFJ2sbfXLx8SMZijCYHOtP/y5nnUb/Rm2omxbDMmtUoSaUtKaw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+        "@babel/runtime": "^7.28.6"
       },
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -2625,36 +1788,13 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-<<<<<<< HEAD
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.9.tgz",
-      "integrity": "sha512-OKRBiajrrxB9ATokgEQoG87Z25c67pCpYcCwmXYX8PBftC9pBfN18gnm/fh1wurSLEKIAt+QRFLFCQISrb66Jg==",
-=======
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
       "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-<<<<<<< HEAD
-        "@emnapi/core": "^1.4.0",
-        "@emnapi/runtime": "^1.4.0",
-        "@tybys/wasm-util": "^0.9.0"
-      }
-    },
-    "node_modules/@next/env": {
-      "version": "14.2.28",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.28.tgz",
-      "integrity": "sha512-PAmWhJfJQlP+kxZwCjrVd9QnR5x0R3u0mTXTiZDgSd4h5LdXmjxCCWbN9kq6hkZBOax8Rm3xDW5HagWyJuT37g==",
-      "license": "MIT"
-    },
-    "node_modules/@next/eslint-plugin-next": {
-      "version": "14.2.28",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.2.28.tgz",
-      "integrity": "sha512-GQUPA1bTZy5qZdPV5MOHB18465azzhg8xm5o2SqxMF+h1rWNjB43y6xmIPHG5OV2OiU3WxuINpusXom49DdaIQ==",
-=======
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
@@ -2670,7 +1810,6 @@
       "version": "14.2.35",
       "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.2.35.tgz",
       "integrity": "sha512-Jw9A3ICz2183qSsqwi7fgq4SBPiNfmOLmTPXKvlnzstUwyvBrtySiY+8RXJweNAs9KThb1+bYhZh9XWcNOr2zQ==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2678,15 +1817,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-<<<<<<< HEAD
-      "version": "14.2.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.28.tgz",
-      "integrity": "sha512-kzGChl9setxYWpk3H6fTZXXPFFjg7urptLq5o5ZgYezCrqlemKttwMT5iFyx/p1e/JeglTwDFRtb923gTJ3R1w==",
-=======
       "version": "14.2.33",
       "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz",
       "integrity": "sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "cpu": [
         "arm64"
       ],
@@ -2700,15 +1833,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-<<<<<<< HEAD
-      "version": "14.2.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.28.tgz",
-      "integrity": "sha512-z6FXYHDJlFOzVEOiiJ/4NG8aLCeayZdcRSMjPDysW297Up6r22xw6Ea9AOwQqbNsth8JNgIK8EkWz2IDwaLQcw==",
-=======
       "version": "14.2.33",
       "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz",
       "integrity": "sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "cpu": [
         "x64"
       ],
@@ -2722,15 +1849,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-<<<<<<< HEAD
-      "version": "14.2.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.28.tgz",
-      "integrity": "sha512-9ARHLEQXhAilNJ7rgQX8xs9aH3yJSj888ssSjJLeldiZKR4D7N08MfMqljk77fAwZsWwsrp8ohHsMvurvv9liQ==",
-=======
       "version": "14.2.33",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz",
       "integrity": "sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "cpu": [
         "arm64"
       ],
@@ -2744,15 +1865,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-<<<<<<< HEAD
-      "version": "14.2.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.28.tgz",
-      "integrity": "sha512-p6gvatI1nX41KCizEe6JkF0FS/cEEF0u23vKDpl+WhPe/fCTBeGkEBh7iW2cUM0rvquPVwPWdiUR6Ebr/kQWxQ==",
-=======
       "version": "14.2.33",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz",
       "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "cpu": [
         "arm64"
       ],
@@ -2766,15 +1881,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-<<<<<<< HEAD
-      "version": "14.2.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.28.tgz",
-      "integrity": "sha512-nsiSnz2wO6GwMAX2o0iucONlVL7dNgKUqt/mDTATGO2NY59EO/ZKnKEr80BJFhuA5UC1KZOMblJHWZoqIJddpA==",
-=======
       "version": "14.2.33",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz",
       "integrity": "sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "cpu": [
         "x64"
       ],
@@ -2788,15 +1897,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-<<<<<<< HEAD
-      "version": "14.2.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.28.tgz",
-      "integrity": "sha512-+IuGQKoI3abrXFqx7GtlvNOpeExUH1mTIqCrh1LGFf8DnlUcTmOOCApEnPJUSLrSbzOdsF2ho2KhnQoO0I1RDw==",
-=======
       "version": "14.2.33",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz",
       "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "cpu": [
         "x64"
       ],
@@ -2810,15 +1913,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-<<<<<<< HEAD
-      "version": "14.2.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.28.tgz",
-      "integrity": "sha512-l61WZ3nevt4BAnGksUVFKy2uJP5DPz2E0Ma/Oklvo3sGj9sw3q7vBWONFRgz+ICiHpW5mV+mBrkB3XEubMrKaA==",
-=======
       "version": "14.2.33",
       "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz",
       "integrity": "sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "cpu": [
         "arm64"
       ],
@@ -2832,15 +1929,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-<<<<<<< HEAD
-      "version": "14.2.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.28.tgz",
-      "integrity": "sha512-+Kcp1T3jHZnJ9v9VTJ/yf1t/xmtFAc/Sge4v7mVc1z+NYfYzisi8kJ9AsY8itbgq+WgEwMtOpiLLJsUy2qnXZw==",
-=======
       "version": "14.2.33",
       "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz",
       "integrity": "sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "cpu": [
         "ia32"
       ],
@@ -2854,15 +1945,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-<<<<<<< HEAD
-      "version": "14.2.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.28.tgz",
-      "integrity": "sha512-1gCmpvyhz7DkB1srRItJTnmR2UwQPAUXXIg9r0/56g3O8etGmwlX68skKXJOp9EejW3hhv7nSQUJ2raFiz4MoA==",
-=======
       "version": "14.2.33",
       "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
       "integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "cpu": [
         "x64"
       ],
@@ -2936,25 +2021,16 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "license": "MIT",
-<<<<<<< HEAD
-=======
       "peer": true,
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@prisma/client": {
-<<<<<<< HEAD
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.6.0.tgz",
-      "integrity": "sha512-vfp73YT/BHsWWOAuthKQ/1lBgESSqYqAWZEYyTdGXyFAHpmewwWL2Iz6ErIzkj4aHbuc6/cGSsE6ZY+pBO04Cg==",
-=======
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.19.1.tgz",
-      "integrity": "sha512-4SXj4Oo6HyQkLUWT8Ke5R0PTAfVOKip5Roo+6+b2EDTkFg5be0FnBWiuRJc0BC0sRQIWGMLKW1XguhVfW/z3/A==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.19.2.tgz",
+      "integrity": "sha512-gR2EMvfK/aTxsuooaDA32D8v+us/8AAet+C3J1cc04SW35FPdZYgLF+iN4NDLUgAaUGTKdAB0CYenu1TAgGdMg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2974,25 +2050,9 @@
       }
     },
     "node_modules/@prisma/config": {
-<<<<<<< HEAD
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.6.0.tgz",
-      "integrity": "sha512-d8FlXRHsx72RbN8nA2QCRORNv5AcUnPXgtPvwhXmYkQSMF/j9cKaJg+9VcUzBRXGy9QBckNzEQDEJZdEOZ+ubA==",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "esbuild": ">=0.12 <1",
-        "esbuild-register": "3.6.0"
-      }
-    },
-    "node_modules/@prisma/debug": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.6.0.tgz",
-      "integrity": "sha512-DL6n4IKlW5k2LEXzpN60SQ1kP/F6fqaCgU/McgaYsxSf43GZ8lwtmXLke9efS+L1uGmrhtBUP4npV/QKF8s2ZQ==",
-=======
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.1.tgz",
-      "integrity": "sha512-bUL/aYkGXLwxVGhJmQMtslLT7KPEfUqmRa919fKI4wQFX4bIFUKiY8Jmio/2waAjjPYrtuDHa7EsNCnJTXxiOw==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.2.tgz",
+      "integrity": "sha512-kadBGDl+aUswv/zZMk9Mx0C8UZs1kjao8H9/JpI4Wh4SHZaM7zkTwiKn/iFLfRg+XtOAo/Z/c6pAYhijKl0nzQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3003,107 +2063,59 @@
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.1.tgz",
-      "integrity": "sha512-h1JImhlAd/s5nhY/e9qkAzausWldbeT+e4nZF7A4zjDYBF4BZmKDt4y0jK7EZapqOm1kW7V0e9agV/iFDy3fWw==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.2.tgz",
+      "integrity": "sha512-lFnEZsLdFLmEVCVNdskLDCL8Uup41GDfU0LUfquw+ercJC8ODTuL0WNKgOKmYxCJVvFwf0OuZBzW99DuWmoH2A==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
-<<<<<<< HEAD
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.6.0.tgz",
-      "integrity": "sha512-nC0IV4NHh7500cozD1fBoTwTD1ydJERndreIjpZr/S3mno3P6tm8qnXmIND5SwUkibNeSJMpgl4gAnlqJ/gVlg==",
-=======
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.1.tgz",
-      "integrity": "sha512-xy95dNJ7DiPf9IJ3oaVfX785nbFl7oNDzclUF+DIiJw6WdWCvPl0LPU0YqQLsrwv8N64uOQkH391ujo3wSo+Nw==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.2.tgz",
+      "integrity": "sha512-TTkJ8r+uk/uqczX40wb+ODG0E0icVsMgwCTyTHXehaEfb0uo80M9g1aW1tEJrxmFHeOZFXdI2sTA1j1AgcHi4A==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-<<<<<<< HEAD
-        "@prisma/debug": "6.6.0",
-        "@prisma/engines-version": "6.6.0-53.f676762280b54cd07c770017ed3711ddde35f37a",
-        "@prisma/fetch-engine": "6.6.0",
-        "@prisma/get-platform": "6.6.0"
-      }
-    },
-    "node_modules/@prisma/engines-version": {
-      "version": "6.6.0-53.f676762280b54cd07c770017ed3711ddde35f37a",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.6.0-53.f676762280b54cd07c770017ed3711ddde35f37a.tgz",
-      "integrity": "sha512-JzRaQ5Em1fuEcbR3nUsMNYaIYrOT1iMheenjCvzZblJcjv/3JIuxXN7RCNT5i6lRkLodW5ojCGhR7n5yvnNKrw==",
-=======
-        "@prisma/debug": "6.19.1",
+        "@prisma/debug": "6.19.2",
         "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
-        "@prisma/fetch-engine": "6.19.1",
-        "@prisma/get-platform": "6.19.1"
+        "@prisma/fetch-engine": "6.19.2",
+        "@prisma/get-platform": "6.19.2"
       }
     },
     "node_modules/@prisma/engines-version": {
       "version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7.tgz",
       "integrity": "sha512-03bgb1VD5gvuumNf+7fVGBzfpJPjmqV423l/WxsWk2cNQ42JD0/SsFBPhN6z8iAvdHs07/7ei77SKu7aZfq8bA==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-<<<<<<< HEAD
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.6.0.tgz",
-      "integrity": "sha512-Ohfo8gKp05LFLZaBlPUApM0M7k43a0jmo86YY35u1/4t+vuQH9mRGU7jGwVzGFY3v+9edeb/cowb1oG4buM1yw==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.2.tgz",
+      "integrity": "sha512-h4Ff4Pho+SR1S8XerMCC12X//oY2bG3Iug/fUnudfcXEUnIeRiBdXHFdGlGOgQ3HqKgosTEhkZMvGM9tWtYC+Q==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.6.0",
-        "@prisma/engines-version": "6.6.0-53.f676762280b54cd07c770017ed3711ddde35f37a",
-        "@prisma/get-platform": "6.6.0"
-      }
-    },
-    "node_modules/@prisma/get-platform": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.6.0.tgz",
-      "integrity": "sha512-3qCwmnT4Jh5WCGUrkWcc6VZaw0JY7eWN175/pcb5Z6FiLZZ3ygY93UX0WuV41bG51a6JN/oBH0uywJ90Y+V5eA==",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@prisma/debug": "6.6.0"
-      }
-    },
-    "node_modules/@react-google-maps/api": {
-      "version": "2.20.6",
-      "resolved": "https://registry.npmjs.org/@react-google-maps/api/-/api-2.20.6.tgz",
-      "integrity": "sha512-frxkSHWbd36ayyxrEVopSCDSgJUT1tVKXvQld2IyzU3UnDuqqNA3AZE4/fCdqQb2/zBQx3nrWnZB1wBXDcrjcw==",
-=======
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.1.tgz",
-      "integrity": "sha512-mmgcotdaq4VtAHO6keov3db+hqlBzQS6X7tR7dFCbvXjLVTxBYdSJFRWz+dq7F9p6dvWyy1X0v8BlfRixyQK6g==",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@prisma/debug": "6.19.1",
+        "@prisma/debug": "6.19.2",
         "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
-        "@prisma/get-platform": "6.19.1"
+        "@prisma/get-platform": "6.19.2"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.1.tgz",
-      "integrity": "sha512-zsg44QUiQAnFUyh6Fbt7c9HjMXHwFTqtrgcX7DAZmRgnkPyYT7Sh8Mn8D5PuuDYNtMOYcpLGg576MLfIORsBYw==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.2.tgz",
+      "integrity": "sha512-PGLr06JUSTqIvztJtAzIxOwtWKtJm5WwOG6xpsgD37Rc84FpfUBGLKz65YpJBGtkRQGXTYEFie7pYALocC3MtA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.19.1"
+        "@prisma/debug": "6.19.2"
       }
     },
     "node_modules/@react-google-maps/api": {
       "version": "2.20.8",
       "resolved": "https://registry.npmjs.org/@react-google-maps/api/-/api-2.20.8.tgz",
       "integrity": "sha512-wtLYFtCGXK3qbIz1H5to3JxbosPnKsvjDKhqGylXUb859EskhzR7OpuNt0LqdLarXUtZCJTKzPn3BNaekNIahg==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "license": "MIT",
       "dependencies": {
         "@googlemaps/js-api-loader": "1.16.8",
@@ -3138,22 +2150,16 @@
       "license": "MIT"
     },
     "node_modules/@rushstack/eslint-patch": {
-<<<<<<< HEAD
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.11.0.tgz",
-      "integrity": "sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==",
-=======
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.15.0.tgz",
-      "integrity": "sha512-ojSshQPKwVvSMR8yT2L/QtUkV5SXi/IfDiJ4/8d6UbTPjiHVmxZzUAzGD8Tzks1b9+qQkZa0isUOvYObedITaw==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.16.1.tgz",
+      "integrity": "sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.27.8",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3177,80 +2183,6 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
-<<<<<<< HEAD
-    "node_modules/@supabase/auth-js": {
-      "version": "2.69.1",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.69.1.tgz",
-      "integrity": "sha512-FILtt5WjCNzmReeRLq5wRs3iShwmnWgBvxHfqapC/VoljJl+W8hDAyFmf1NVw3zH+ZjZ05AKxiKxVeb0HNWRMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
-      }
-    },
-    "node_modules/@supabase/functions-js": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.4.tgz",
-      "integrity": "sha512-WL2p6r4AXNGwop7iwvul2BvOtuJ1YQy8EbOd0dhG1oN1q8el/BIRSFCFnWAMM/vJJlHWLi4ad22sKbKr9mvjoA==",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
-      }
-    },
-    "node_modules/@supabase/node-fetch": {
-      "version": "2.6.15",
-      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
-      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      }
-    },
-    "node_modules/@supabase/postgrest-js": {
-      "version": "1.19.4",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.19.4.tgz",
-      "integrity": "sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
-      }
-    },
-    "node_modules/@supabase/realtime-js": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.11.2.tgz",
-      "integrity": "sha512-u/XeuL2Y0QEhXSoIPZZwR6wMXgB+RQbJzG9VErA3VghVt7uRfSVsjeqd7m5GhX3JR6dM/WRmLbVR8URpDWG4+w==",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/node-fetch": "^2.6.14",
-        "@types/phoenix": "^1.5.4",
-        "@types/ws": "^8.5.10",
-        "ws": "^8.18.0"
-      }
-    },
-    "node_modules/@supabase/storage-js": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.7.1.tgz",
-      "integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
-      }
-    },
-    "node_modules/@supabase/supabase-js": {
-      "version": "2.49.4",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.49.4.tgz",
-      "integrity": "sha512-jUF0uRUmS8BKt37t01qaZ88H9yV1mbGYnqLeuFWLcdV+x1P4fl0yP9DGtaEhFPZcwSom7u16GkLEH9QJZOqOkw==",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/auth-js": "2.69.1",
-        "@supabase/functions-js": "2.4.4",
-        "@supabase/node-fetch": "2.6.15",
-        "@supabase/postgrest-js": "1.19.4",
-        "@supabase/realtime-js": "2.11.2",
-        "@supabase/storage-js": "2.7.1"
-=======
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -3259,9 +2191,9 @@
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.89.0",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.89.0.tgz",
-      "integrity": "sha512-wiWZdz8WMad8LQdJMWYDZ2SJtZP5MwMqzQq3ehtW2ngiI3UTgbKiFrvMUUS3KADiVlk4LiGfODB2mrYx7w2f8w==",
+      "version": "2.97.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.97.0.tgz",
+      "integrity": "sha512-2Og/1lqp+AIavr8qS2X04aSl8RBY06y4LrtIAGxat06XoXYiDxKNQMQzWDAKm1EyZFZVRNH48DO5YvIZ7la5fQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -3271,9 +2203,9 @@
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.89.0",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.89.0.tgz",
-      "integrity": "sha512-XEueaC5gMe5NufNYfBh9kPwJlP5M2f+Ogr8rvhmRDAZNHgY6mI35RCkYDijd92pMcNM7g8pUUJov93UGUnqfyw==",
+      "version": "2.97.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.97.0.tgz",
+      "integrity": "sha512-fSaA0ZeBUS9hMgpGZt5shIZvfs3Mvx2ZdajQT4kv/whubqDBAp3GU5W8iIXy21MRvKmO2NpAj8/Q6y+ZkZyF/w==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -3283,9 +2215,9 @@
       }
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "2.89.0",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.89.0.tgz",
-      "integrity": "sha512-/b0fKrxV9i7RNOEXMno/I1862RsYhuUo+Q6m6z3ar1f4ulTMXnDfv0y4YYxK2POcgrOXQOgKYQx1eArybyNvtg==",
+      "version": "2.97.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.97.0.tgz",
+      "integrity": "sha512-g4Ps0eaxZZurvfv/KGoo2XPZNpyNtjth9aW8eho9LZWM0bUuBtxPZw3ZQ6ERSpEGogshR+XNgwlSPIwcuHCNww==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -3295,9 +2227,9 @@
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.89.0",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.89.0.tgz",
-      "integrity": "sha512-aMOvfDb2a52u6PX6jrrjvACHXGV3zsOlWRzZsTIOAJa0hOVvRp01AwC1+nLTGUzxzezejrYeCX+KnnM1xHdl+w==",
+      "version": "2.97.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.97.0.tgz",
+      "integrity": "sha512-37Jw0NLaFP0CZd7qCan97D1zWutPrTSpgWxAw6Yok59JZoxp4IIKMrPeftJ3LZHmf+ILQOPy3i0pRDHM9FY36Q==",
       "license": "MIT",
       "dependencies": {
         "@types/phoenix": "^1.6.6",
@@ -3310,9 +2242,9 @@
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.89.0",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.89.0.tgz",
-      "integrity": "sha512-6zKcXofk/M/4Eato7iqpRh+B+vnxeiTumCIP+Tz26xEqIiywzD9JxHq+udRrDuv6hXE+pmetvJd8n5wcf4MFRQ==",
+      "version": "2.97.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.97.0.tgz",
+      "integrity": "sha512-9f6NniSBfuMxOWKwEFb+RjJzkfMdJUwv9oHuFJKfe/5VJR8cd90qw68m6Hn0ImGtwG37TUO+QHtoOechxRJ1Yg==",
       "license": "MIT",
       "dependencies": {
         "iceberg-js": "^0.8.1",
@@ -3323,20 +2255,19 @@
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.89.0",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.89.0.tgz",
-      "integrity": "sha512-KlaRwSfFA0fD73PYVMHj5/iXFtQGCcX7PSx0FdQwYEEw9b2wqM7GxadY+5YwcmuEhalmjFB/YvqaoNVF+sWUlg==",
+      "version": "2.97.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.97.0.tgz",
+      "integrity": "sha512-kTD91rZNO4LvRUHv4x3/4hNmsEd2ofkYhuba2VMUPRVef1RCmnHtm7rIws38Fg0yQnOSZOplQzafn0GSiy6GVg==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.89.0",
-        "@supabase/functions-js": "2.89.0",
-        "@supabase/postgrest-js": "2.89.0",
-        "@supabase/realtime-js": "2.89.0",
-        "@supabase/storage-js": "2.89.0"
+        "@supabase/auth-js": "2.97.0",
+        "@supabase/functions-js": "2.97.0",
+        "@supabase/postgrest-js": "2.97.0",
+        "@supabase/realtime-js": "2.97.0",
+        "@supabase/storage-js": "2.97.0"
       },
       "engines": {
         "node": ">=20.0.0"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       }
     },
     "node_modules/@swc/counter": {
@@ -3366,15 +2297,9 @@
       }
     },
     "node_modules/@testing-library/dom": {
-<<<<<<< HEAD
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
-      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
-=======
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3383,15 +2308,9 @@
         "@babel/runtime": "^7.12.5",
         "@types/aria-query": "^5.0.1",
         "aria-query": "5.3.0",
-<<<<<<< HEAD
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-=======
         "dom-accessibility-api": "^0.5.9",
         "lz-string": "^1.5.0",
         "picocolors": "1.1.1",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         "pretty-format": "^27.0.2"
       },
       "engines": {
@@ -3399,30 +2318,17 @@
       }
     },
     "node_modules/@testing-library/jest-dom": {
-<<<<<<< HEAD
-      "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz",
-      "integrity": "sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==",
-=======
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
       "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@adobe/css-tools": "^4.4.0",
         "aria-query": "^5.0.0",
-<<<<<<< HEAD
-        "chalk": "^3.0.0",
-        "css.escape": "^1.5.1",
-        "dom-accessibility-api": "^0.6.3",
-        "lodash": "^4.17.21",
-=======
         "css.escape": "^1.5.1",
         "dom-accessibility-api": "^0.6.3",
         "picocolors": "^1.1.1",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         "redent": "^3.0.0"
       },
       "engines": {
@@ -3431,23 +2337,6 @@
         "yarn": ">=1"
       }
     },
-<<<<<<< HEAD
-    "node_modules/@testing-library/jest-dom/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-=======
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
@@ -3456,15 +2345,9 @@
       "license": "MIT"
     },
     "node_modules/@testing-library/react": {
-<<<<<<< HEAD
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
-      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
-=======
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.1.tgz",
-      "integrity": "sha512-gr4KtAWqIOQoucWYD/f6ki+j5chXfcPc74Col/6poTyqTmn7zRmodWahWRCp8tYd+GMqBonw6hstNzqjbs6gjw==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3500,15 +2383,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-<<<<<<< HEAD
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
-      "integrity": "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==",
-=======
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3521,12 +2398,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-<<<<<<< HEAD
-      "license": "MIT",
-      "peer": true
-=======
       "license": "MIT"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3564,21 +2436,6 @@
       }
     },
     "node_modules/@types/babel__traverse": {
-<<<<<<< HEAD
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.7.tgz",
-      "integrity": "sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.20.7"
-      }
-    },
-    "node_modules/@types/d3-array": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
-      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
-=======
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
       "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
@@ -3592,7 +2449,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
       "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "license": "MIT"
     },
     "node_modules/@types/d3-color": {
@@ -3632,9 +2488,9 @@
       }
     },
     "node_modules/@types/d3-shape": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
-      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
       "license": "MIT",
       "dependencies": {
         "@types/d3-path": "*"
@@ -3787,23 +2643,9 @@
       }
     },
     "node_modules/@types/node": {
-<<<<<<< HEAD
-      "version": "20.17.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.30.tgz",
-      "integrity": "sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
-      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
-=======
-      "version": "20.19.27",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.27.tgz",
-      "integrity": "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==",
+      "version": "20.19.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
+      "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -3813,44 +2655,10 @@
       "version": "2.6.13",
       "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
       "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
-<<<<<<< HEAD
-        "form-data": "^4.0.0"
-      }
-    },
-    "node_modules/@types/phoenix": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
-      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
-      "license": "MIT"
-    },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.14",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
-      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "license": "MIT"
-    },
-    "node_modules/@types/react": {
-      "version": "18.3.20",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.20.tgz",
-      "integrity": "sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@types/react-dom": {
-      "version": "18.3.6",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.6.tgz",
-      "integrity": "sha512-nf22//wEbKXusP6E9pfOCDwFdHAX4u172eaJI4YkDRQEZiorm6KfYnSC2SWLDMVWUOWPERmJnN0ujeAfTBLvrw==",
-      "dev": true,
-      "license": "MIT",
-=======
         "form-data": "^4.0.4"
       }
     },
@@ -3867,9 +2675,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "18.3.27",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
-      "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3884,7 +2692,6 @@
       "dev": true,
       "license": "MIT",
       "peer": true,
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -3985,15 +2792,6 @@
       }
     },
     "node_modules/@types/webpack-sources/node_modules/source-map": {
-<<<<<<< HEAD
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 8"
-=======
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
       "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
@@ -4001,7 +2799,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 12"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       }
     },
     "node_modules/@types/ws": {
@@ -4014,15 +2811,9 @@
       }
     },
     "node_modules/@types/yargs": {
-<<<<<<< HEAD
-      "version": "17.0.33",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
-      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
-=======
       "version": "17.0.35",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
       "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4037,37 +2828,20 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-<<<<<<< HEAD
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.31.0.tgz",
-      "integrity": "sha512-evaQJZ/J/S4wisevDvC1KFZkPzRetH8kYZbkgcTRyql3mcKsf+ZFDV1BVWUGTCAW5pQHoqn5gK5b8kn7ou9aFQ==",
-=======
-      "version": "8.50.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.50.0.tgz",
-      "integrity": "sha512-O7QnmOXYKVtPrfYzMolrCTfkezCJS9+ljLdKW/+DCvRsc3UAz+sbH6Xcsv7p30+0OwUbeWfUDAQE0vpabZ3QLg==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.0.tgz",
+      "integrity": "sha512-lRyPDLzNCuae71A3t9NEINBiTn7swyOhvUj3MyUOxb8x6g6vPEFoOU+ZRmGMusNC3X3YMhqMIX7i8ShqhT74Pw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-<<<<<<< HEAD
-        "@typescript-eslint/scope-manager": "8.31.0",
-        "@typescript-eslint/type-utils": "8.31.0",
-        "@typescript-eslint/utils": "8.31.0",
-        "@typescript-eslint/visitor-keys": "8.31.0",
-        "graphemer": "^1.4.0",
-        "ignore": "^5.3.1",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.56.0",
+        "@typescript-eslint/type-utils": "8.56.0",
+        "@typescript-eslint/utils": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.0.1"
-=======
-        "@typescript-eslint/scope-manager": "8.50.0",
-        "@typescript-eslint/type-utils": "8.50.0",
-        "@typescript-eslint/utils": "8.50.0",
-        "@typescript-eslint/visitor-keys": "8.50.0",
-        "ignore": "^7.0.0",
-        "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.1.0"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4077,26 +2851,8 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-<<<<<<< HEAD
-        "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
-      }
-    },
-    "node_modules/@typescript-eslint/parser": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.31.0.tgz",
-      "integrity": "sha512-67kYYShjBR0jNI5vsf/c3WG4u+zDnCTHTPqVMQguffaWWFs7artgwKmfwdifl+r6XyM5LYLas/dInj2T0SgJyw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "8.31.0",
-        "@typescript-eslint/types": "8.31.0",
-        "@typescript-eslint/typescript-estree": "8.31.0",
-        "@typescript-eslint/visitor-keys": "8.31.0",
-=======
-        "@typescript-eslint/parser": "^8.50.0",
-        "eslint": "^8.57.0 || ^9.0.0",
+        "@typescript-eslint/parser": "^8.56.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
@@ -4111,19 +2867,18 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.50.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.50.0.tgz",
-      "integrity": "sha512-6/cmF2piao+f6wSxUsJLZjck7OQsYyRtcOZS02k7XINSNlz93v6emM8WutDQSXnroG2xwYlEVHJI+cPA7CPM3Q==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.0.tgz",
+      "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.50.0",
-        "@typescript-eslint/types": "8.50.0",
-        "@typescript-eslint/typescript-estree": "8.50.0",
-        "@typescript-eslint/visitor-keys": "8.50.0",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.56.0",
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4133,34 +2888,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-<<<<<<< HEAD
-        "typescript": ">=4.8.4 <5.9.0"
-      }
-    },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.31.0.tgz",
-      "integrity": "sha512-knO8UyF78Nt8O/B64i7TlGXod69ko7z6vJD9uhSlm0qkAbGeRUSudcm0+K/4CrRjrpiHfBCjMWlc08Vav1xwcw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.31.0",
-        "@typescript-eslint/visitor-keys": "8.31.0"
-=======
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.50.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.50.0.tgz",
-      "integrity": "sha512-Cg/nQcL1BcoTijEWyx4mkVC56r8dj44bFDvBdygifuS20f3OZCHmFbjF34DPSi07kwlFvqfv/xOLnJ5DquxSGQ==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.0.tgz",
+      "integrity": "sha512-M3rnyL1vIQOMeWxTWIW096/TtVP+8W3p/XnaFflhmcFp+U4zlxUxWj4XwNs6HbDeTtN4yun0GNTTDBw/SvufKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.50.0",
-        "@typescript-eslint/types": "^8.50.0",
-        "debug": "^4.3.4"
+        "@typescript-eslint/tsconfig-utils": "^8.56.0",
+        "@typescript-eslint/types": "^8.56.0",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4174,15 +2915,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.50.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.50.0.tgz",
-      "integrity": "sha512-xCwfuCZjhIqy7+HKxBLrDVT5q/iq7XBVBXLn57RTIIpelLtEIZHXAF/Upa3+gaCpeV1NNS5Z9A+ID6jn50VD4A==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.0.tgz",
+      "integrity": "sha512-7UiO/XwMHquH+ZzfVCfUNkIXlp/yQjjnlYUyYz7pfvlK3/EyyN6BK+emDmGNyQLBtLGaYrTAI6KOw8tFucWL2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.50.0",
-        "@typescript-eslint/visitor-keys": "8.50.0"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4192,23 +2932,10 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-<<<<<<< HEAD
-    "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.31.0.tgz",
-      "integrity": "sha512-DJ1N1GdjI7IS7uRlzJuEDCgDQix3ZVYVtgeWEyhyn4iaoitpMBX6Ndd488mXSx0xah/cONAkEaYyylDyAeHMHg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.31.0",
-        "@typescript-eslint/utils": "8.31.0",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.0.1"
-=======
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.50.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.50.0.tgz",
-      "integrity": "sha512-vxd3G/ybKTSlm31MOA96gqvrRGv9RJ7LGtZCn2Vrc5htA0zCDvcMqUkifcjrWNNKXHUU3WCkYOzzVSFBd0wa2w==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.0.tgz",
+      "integrity": "sha512-bSJoIIt4o3lKXD3xmDh9chZcjCz5Lk8xS7Rxn+6l5/pKrDpkCwtQNQQwZ2qRPk7TkUYhrq3WPIHXOXlbXP0itg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4223,18 +2950,17 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.50.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.50.0.tgz",
-      "integrity": "sha512-7OciHT2lKCewR0mFoBrvZJ4AXTMe/sYOe87289WAViOocEmDjjv8MvIOT2XESuKj9jp8u3SZYUSh89QA4S1kQw==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.0.tgz",
+      "integrity": "sha512-qX2L3HWOU2nuDs6GzglBeuFXviDODreS58tLY/BALPC7iu3Fa+J7EOTwnX9PdNBxUI7Uh0ntP0YWGnxCkXzmfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.50.0",
-        "@typescript-eslint/typescript-estree": "8.50.0",
-        "@typescript-eslint/utils": "8.50.0",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.1.0"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0",
+        "@typescript-eslint/utils": "8.56.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4244,24 +2970,14 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-<<<<<<< HEAD
-        "typescript": ">=4.8.4 <5.9.0"
-      }
-    },
-    "node_modules/@typescript-eslint/types": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.31.0.tgz",
-      "integrity": "sha512-Ch8oSjVyYyJxPQk8pMiP2FFGYatqXQfQIaMp+TpuuLlDachRWpUAeEu1u9B/v/8LToehUIWyiKcA/w5hUFRKuQ==",
-=======
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.50.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.50.0.tgz",
-      "integrity": "sha512-iX1mgmGrXdANhhITbpp2QQM2fGehBse9LbTf0sidWK6yg/NE+uhV5dfU1g6EYPlcReYmkE9QLPq/2irKAmtS9w==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.0.tgz",
+      "integrity": "sha512-DBsLPs3GsWhX5HylbP9HNG15U0bnwut55Lx12bHB9MpXxQ+R5GC8MwQe+N1UFXxAeQDvEsEDY6ZYwX03K7Z6HQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4273,38 +2989,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-<<<<<<< HEAD
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.31.0.tgz",
-      "integrity": "sha512-xLmgn4Yl46xi6aDSZ9KkyfhhtnYI15/CvHbpOy/eR5NWhK/BK8wc709KKwhAR0m4ZKRP7h07bm4BWUYOCuRpQQ==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.0.tgz",
+      "integrity": "sha512-ex1nTUMWrseMltXUHmR2GAQ4d+WjkZCT4f+4bVsps8QEdh0vlBsaCokKTPlnqBFqqGaxilDNJG7b8dolW2m43Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.31.0",
-        "@typescript-eslint/visitor-keys": "8.31.0",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^2.0.1"
-=======
-      "version": "8.50.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.50.0.tgz",
-      "integrity": "sha512-W7SVAGBR/IX7zm1t70Yujpbk+zdPq/u4soeFSknWFdXIFuWsBGBOUu/Tn/I6KHSKvSh91OiMuaSnYp3mtPt5IQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/project-service": "8.50.0",
-        "@typescript-eslint/tsconfig-utils": "8.50.0",
-        "@typescript-eslint/types": "8.50.0",
-        "@typescript-eslint/visitor-keys": "8.50.0",
-        "debug": "^4.3.4",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
+        "@typescript-eslint/project-service": "8.56.0",
+        "@typescript-eslint/tsconfig-utils": "8.56.0",
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0",
+        "debug": "^4.4.3",
+        "minimatch": "^9.0.5",
+        "semver": "^7.7.3",
         "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.1.0"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4314,37 +3013,40 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-<<<<<<< HEAD
-        "typescript": ">=4.8.4 <5.9.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-=======
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
+      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
+      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
+      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -4354,29 +3056,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-<<<<<<< HEAD
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.31.0.tgz",
-      "integrity": "sha512-qi6uPLt9cjTFxAb1zGNgTob4x9ur7xC6mHQJ8GwEzGMGE9tYniublmJaowOJ9V2jUzxrltTPfdG2nKlWsq0+Ww==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.0.tgz",
+      "integrity": "sha512-RZ3Qsmi2nFGsS+n+kjLAYDPVlrzf7UhTffrDIKr+h2yzAlYP/y5ZulU0yeDEPItos2Ph46JAL5P/On3pe7kDIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.31.0",
-        "@typescript-eslint/types": "8.31.0",
-        "@typescript-eslint/typescript-estree": "8.31.0"
-=======
-      "version": "8.50.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.50.0.tgz",
-      "integrity": "sha512-87KgUXET09CRjGCi2Ejxy3PULXna63/bMYv72tCAlDJC3Yqwln0HiFJ3VJMst2+mEtNtZu5oFvX4qJGjKsnAgg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.50.0",
-        "@typescript-eslint/types": "8.50.0",
-        "@typescript-eslint/typescript-estree": "8.50.0"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.56.0",
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4386,34 +3075,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-<<<<<<< HEAD
-        "typescript": ">=4.8.4 <5.9.0"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.31.0.tgz",
-      "integrity": "sha512-QcGHmlRHWOl93o64ZUMNewCdwKGU6WItOU52H0djgNmn1EOrhVudrDzXz4OycCRSCPwFCDrE2iIt5vmuUdHxuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.31.0",
-        "eslint-visitor-keys": "^4.2.0"
-=======
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.50.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.50.0.tgz",
-      "integrity": "sha512-Xzmnb58+Db78gT/CCj/PVCvK+zxbnsw6F+O1oheYszJbBSdEjVhQi3C/Xttzxgi/GLmpvOggRs1RFpiJ8+c34Q==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.0.tgz",
+      "integrity": "sha512-q+SL+b+05Ud6LbEE35qe4A99P+htKTKVbyiNEe45eCbJFyh/HVK9QXwlrbz+Q4L8SOW4roxSVwXYj4DMBT7Ieg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.50.0",
-        "eslint-visitor-keys": "^4.2.1"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+        "@typescript-eslint/types": "8.56.0",
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4424,19 +3098,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-<<<<<<< HEAD
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
-=======
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -4449,12 +3117,6 @@
       "dev": true,
       "license": "ISC"
     },
-<<<<<<< HEAD
-    "node_modules/@unrs/resolver-binding-darwin-arm64": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.6.6.tgz",
-      "integrity": "sha512-wl51lfW6npeDEQRsPuxbsuj2ob5TagPTamBBLNe+tFPwNAFeTCc9OgE5hOaw/niCMalv404rXYgqXaChH4Uuug==",
-=======
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
@@ -4487,7 +3149,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
       "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "cpu": [
         "arm64"
       ],
@@ -4499,15 +3160,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-darwin-x64": {
-<<<<<<< HEAD
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.6.6.tgz",
-      "integrity": "sha512-RaXHozkr8dwlDdjgX5zbOSFSodWhXiJBMxtNS4YXtdrh/oEgXbPKsEYRFhww8VWgjZN6tb9gHrxcmvkwFj6euQ==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
       "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "cpu": [
         "x64"
       ],
@@ -4519,15 +3174,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-freebsd-x64": {
-<<<<<<< HEAD
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.6.6.tgz",
-      "integrity": "sha512-Hg5MUUAECYQjUjWqprv4sIcMtinD6ZH6uYvZ4fULdr+zbE4fvfxgAAEXMh2EbJWeLl/MlmymoVWU5UKb3vOcjg==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
       "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "cpu": [
         "x64"
       ],
@@ -4539,15 +3188,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-<<<<<<< HEAD
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.6.6.tgz",
-      "integrity": "sha512-gdeE9M/P5QT4pnV5ZaMYVt3BOCR41iaQuT0pYpE5dBHufrsTU7VnvdrMKTAyC2Osx6Ut2BXsCzFtzmmgWeX/BQ==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
       "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "cpu": [
         "arm"
       ],
@@ -4559,15 +3202,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-<<<<<<< HEAD
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.6.6.tgz",
-      "integrity": "sha512-Bpu2F+oonvmalvJgqrGxjIe8nEp1xuWS7q40Fc8ipebmtVb3ja2TlMfP8Yhs923vQpMlpAjJs0vS0I5l/+UeUg==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
       "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "cpu": [
         "arm"
       ],
@@ -4579,15 +3216,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-<<<<<<< HEAD
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.6.6.tgz",
-      "integrity": "sha512-xK2GF0yDUaZoOexUwvsqdPgJA3r1f5oULY4EG8EfUcN0ASnz4R5zPTZ/iegeeZ0jt3VLdo5NXVLqoIyHlklB0w==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
       "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "cpu": [
         "arm64"
       ],
@@ -4599,15 +3230,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-<<<<<<< HEAD
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.6.6.tgz",
-      "integrity": "sha512-G0pDs+aSp1UYRpvm1VCGA2nqTKCTIL7F3n1SLl5johiBgGW4gt4czGTOSMLQ+0P/Zh1YKH1GMAvuIdjKbcMrzQ==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
       "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "cpu": [
         "arm64"
       ],
@@ -4619,15 +3244,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-<<<<<<< HEAD
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.6.6.tgz",
-      "integrity": "sha512-esQ1iXvYdhFM+kID6dmtNdH9+FyK3EWysGhVx+P1vh08Z/b7Wp4o7/T9HJ6tgcsoTahLw4qMAp3dh5EFtacMvg==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
       "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "cpu": [
         "ppc64"
       ],
@@ -4639,15 +3258,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-<<<<<<< HEAD
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.6.6.tgz",
-      "integrity": "sha512-/YRZW3bIl7gnFc25kT3aJ4tehqNw/EZz/e8o2XeicS2H48wOpVh5ACNZr6nHluuVjRTsUzdBhtN+nO6/SSrlYQ==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
       "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "cpu": [
         "riscv64"
       ],
@@ -4659,15 +3272,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-<<<<<<< HEAD
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.6.6.tgz",
-      "integrity": "sha512-gZjhCzbo0V7DyZ5KVIbtGx004r+xWHfH9qB6ds+J71Yo0a197GGPsXJ0G7gO74P3GFMfSNvQP22my2xh8y5/sg==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
       "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "cpu": [
         "riscv64"
       ],
@@ -4679,15 +3286,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-<<<<<<< HEAD
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.6.6.tgz",
-      "integrity": "sha512-Gpaqnz0voRMADxwaD1KS1G5pXAODQellDMoV4Ge6TVOqbrmhVL5oWfVQ+/LZKUIYDSCXaZlR9yKe84CnDw3uUQ==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
       "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "cpu": [
         "s390x"
       ],
@@ -4699,15 +3300,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-<<<<<<< HEAD
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.6.6.tgz",
-      "integrity": "sha512-GRYb1Iz3BNSu27OHsqqIhlgPieHqi4PyUOloKK6YcQiy9uJdJgWYuIx5vFLQP0Sy+lR+TrbZkUiKOCAqhz2ZlQ==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
       "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "cpu": [
         "x64"
       ],
@@ -4719,15 +3314,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-musl": {
-<<<<<<< HEAD
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.6.6.tgz",
-      "integrity": "sha512-qdzNiIN3L4fWbCfTtso7FRTLJS6Y0j+46JSilv0hJsrnUb+54KRtOW6F39dozsyy5pLY2paQ4kZn6cTOTn7Q2g==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
       "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "cpu": [
         "x64"
       ],
@@ -4739,15 +3328,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-wasm32-wasi": {
-<<<<<<< HEAD
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.6.6.tgz",
-      "integrity": "sha512-x2F72mL32g9r4/WdVZ42nm8t9J9kTQeacxwKDmoH6K9Z9/welx0VUOHfkivcuhjTXzqcc1mgmtW0q2Uj53MRIA==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
       "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "cpu": [
         "wasm32"
       ],
@@ -4755,26 +3338,16 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-<<<<<<< HEAD
-        "@napi-rs/wasm-runtime": "^0.2.9"
-=======
         "@napi-rs/wasm-runtime": "^0.2.11"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-<<<<<<< HEAD
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.6.6.tgz",
-      "integrity": "sha512-YwMypHIrhX0eYZov/hYRceOS16gZKLce0RJqUueKOIXJB2+72Gaeb5n3idy727WPvv7Nq3RNiy4izU6qaH9yNg==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
       "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "cpu": [
         "arm64"
       ],
@@ -4786,15 +3359,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-<<<<<<< HEAD
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.6.6.tgz",
-      "integrity": "sha512-dfojnFJJ4j4oKD2e0BJx5X6+1EjHLC8k7y3PIEYLouvbwDQtD95Pu5DxNRIYATYMTpzPUD0uUFdWL+77CC8/MA==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
       "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "cpu": [
         "ia32"
       ],
@@ -4806,15 +3373,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-<<<<<<< HEAD
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.6.6.tgz",
-      "integrity": "sha512-63KJGFohh6mArrCJYL3wWyrd/tkMGYqSjOnHoHAMZR1H7MndCxphD6ofXxNXDb8J3hcUXKdRI6BcFeSN4/c5Ew==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
       "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "cpu": [
         "x64"
       ],
@@ -4834,20 +3395,12 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/acorn": {
-<<<<<<< HEAD
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
-      "dev": true,
-      "license": "MIT",
-=======
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4877,9 +3430,9 @@
       }
     },
     "node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4903,9 +3456,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5037,20 +3590,6 @@
       }
     },
     "node_modules/array-includes": {
-<<<<<<< HEAD
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.8.tgz",
-      "integrity": "sha512-itaWrbYbqpGXkGhZPGUulwnhVf5Hpy1xiCFsGqyIGglbBxmG5vSjxQen3/WGOjPpNEv1RtBLKxbmVXm8HpJStQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-object-atoms": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
-        "is-string": "^1.0.7"
-=======
       "version": "3.1.9",
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
       "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
@@ -5065,7 +3604,6 @@
         "get-intrinsic": "^1.3.0",
         "is-string": "^1.1.1",
         "math-intrinsics": "^1.1.0"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       },
       "engines": {
         "node": ">= 0.4"
@@ -5201,16 +3739,6 @@
       "dev": true,
       "license": "MIT"
     },
-<<<<<<< HEAD
-    "node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "dev": true,
-      "license": "MIT"
-    },
-=======
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -5244,15 +3772,9 @@
       }
     },
     "node_modules/axe-core": {
-<<<<<<< HEAD
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
-      "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
-=======
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.0.tgz",
-      "integrity": "sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
+      "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -5260,23 +3782,13 @@
       }
     },
     "node_modules/axios": {
-<<<<<<< HEAD
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-=======
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -5373,15 +3885,9 @@
       }
     },
     "node_modules/babel-preset-current-node-syntax": {
-<<<<<<< HEAD
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.1.0.tgz",
-      "integrity": "sha512-ldYss8SbBlWva1bs28q78Ju5Zq1F+8BrqBZZ0VFhLBvhh6lCpC2o3gDJi/5DRLs9FgYZCnmPYIVFU4lRXCkyUw==",
-=======
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
       "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5402,11 +3908,7 @@
         "@babel/plugin-syntax-top-level-await": "^7.14.5"
       },
       "peerDependencies": {
-<<<<<<< HEAD
-        "@babel/core": "^7.0.0"
-=======
         "@babel/core": "^7.0.0 || ^8.0.0-0"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       }
     },
     "node_modules/babel-preset-jest": {
@@ -5433,19 +3935,19 @@
       "dev": true,
       "license": "MIT"
     },
-<<<<<<< HEAD
-=======
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.11",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
-      "integrity": "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
+      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -5460,15 +3962,9 @@
       }
     },
     "node_modules/bootstrap": {
-<<<<<<< HEAD
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.5.tgz",
-      "integrity": "sha512-ct1CHKtiobRimyGzmsSldEtM03E8fcEX4Tb3dGXz1V8faRwM50+vfHwTzOxB3IlKO7m+9vTH3s/3C6T2EAPeTA==",
-=======
       "version": "5.3.8",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
       "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "funding": [
         {
           "type": "github",
@@ -5485,15 +3981,9 @@
       }
     },
     "node_modules/bootstrap-icons": {
-<<<<<<< HEAD
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.11.3.tgz",
-      "integrity": "sha512-+3lpHrCw/it2/7lBL15VR0HEumaBss0+f/Lb6ZvHISn1mlK83jjFpooTLsMWbIjJMDjDjOExMsTxnXSIT4k4ww==",
-=======
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.13.1.tgz",
       "integrity": "sha512-ijombt4v6bv5CLeXvRWKy7CuM3TRTuPEuGaGKvTV5cz65rQSY8RQ2JcHt6b90cBBAC7s8fsf2EkQDldzCoXUjw==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "funding": [
         {
           "type": "github",
@@ -5507,15 +3997,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-<<<<<<< HEAD
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-=======
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5545,15 +4029,9 @@
       }
     },
     "node_modules/browserslist": {
-<<<<<<< HEAD
-      "version": "4.24.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
-      "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
-=======
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
       "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "funding": [
         {
@@ -5570,13 +4048,6 @@
         }
       ],
       "license": "MIT",
-<<<<<<< HEAD
-      "dependencies": {
-        "caniuse-lite": "^1.0.30001688",
-        "electron-to-chromium": "^1.5.73",
-        "node-releases": "^2.0.19",
-        "update-browserslist-db": "^1.1.1"
-=======
       "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
@@ -5584,7 +4055,6 @@
         "electron-to-chromium": "^1.5.263",
         "node-releases": "^2.0.27",
         "update-browserslist-db": "^1.2.0"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       },
       "bin": {
         "browserslist": "cli.js"
@@ -5640,8 +4110,6 @@
         "node": ">=10.16.0"
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/c12": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
@@ -5671,7 +4139,6 @@
         }
       }
     },
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -5752,15 +4219,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-<<<<<<< HEAD
-      "version": "1.0.30001715",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001715.tgz",
-      "integrity": "sha512-7ptkFGMm2OAOgvZpwgA4yjQ5SQbrNVGdRjzH0pBdy1Fasvcr+KAeECmbCAECzTuDuoX0FCY8KzUxjf9+9kfZEw==",
-=======
-      "version": "1.0.30001761",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001761.tgz",
-      "integrity": "sha512-JF9ptu1vP2coz98+5051jZ4PwQgd2ni8A+gYSN7EA7dPKIMf0pDlSUxhdmVOaV3/fYK5uWBkgSXJaRLr4+3A6g==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+      "version": "1.0.30001770",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001770.tgz",
+      "integrity": "sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==",
       "funding": [
         {
           "type": "opencollective",
@@ -5805,43 +4266,6 @@
       }
     },
     "node_modules/chokidar": {
-<<<<<<< HEAD
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/chokidar/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-=======
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
@@ -5855,7 +4279,6 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       }
     },
     "node_modules/ci-info": {
@@ -5874,8 +4297,6 @@
         "node": ">=8"
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/citty": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
@@ -5886,7 +4307,6 @@
         "consola": "^3.2.3"
       }
     },
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/cjs-module-lexer": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
@@ -5976,15 +4396,9 @@
       }
     },
     "node_modules/collect-v8-coverage": {
-<<<<<<< HEAD
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
-      "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
-=======
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
       "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT"
     },
@@ -6037,12 +4451,10 @@
       "dev": true,
       "license": "MIT"
     },
-<<<<<<< HEAD
-=======
     "node_modules/confbox": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
-      "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -6056,7 +4468,6 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -6149,18 +4560,11 @@
       "license": "MIT"
     },
     "node_modules/csstype": {
-<<<<<<< HEAD
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "license": "MIT"
-=======
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT",
       "peer": true
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -6193,9 +4597,9 @@
       }
     },
     "node_modules/d3-format": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -6305,36 +4709,6 @@
         "node": ">=12"
       }
     },
-<<<<<<< HEAD
-    "node_modules/data-urls/node_modules/tr46": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/data-urls/node_modules/whatwg-url": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "^3.0.0",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-=======
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -6390,17 +4764,10 @@
       }
     },
     "node_modules/debug": {
-<<<<<<< HEAD
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "devOptional": true,
-=======
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -6415,15 +4782,9 @@
       }
     },
     "node_modules/decimal.js": {
-<<<<<<< HEAD
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
-      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
-=======
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT"
     },
@@ -6434,15 +4795,9 @@
       "license": "MIT"
     },
     "node_modules/dedent": {
-<<<<<<< HEAD
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
-      "integrity": "sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==",
-=======
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
       "integrity": "sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -6471,8 +4826,6 @@
         "node": ">=0.10.0"
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/deepmerge-ts": {
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
@@ -6483,7 +4836,6 @@
         "node": ">=16.0.0"
       }
     },
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -6520,8 +4872,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/defu": {
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
@@ -6529,7 +4879,6 @@
       "devOptional": true,
       "license": "MIT"
     },
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -6548,8 +4897,6 @@
         "node": ">=6"
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/destr": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
@@ -6557,7 +4904,6 @@
       "devOptional": true,
       "license": "MIT"
     },
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -6610,12 +4956,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-<<<<<<< HEAD
-      "license": "MIT",
-      "peer": true
-=======
       "license": "MIT"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -6641,8 +4982,6 @@
         "node": ">=12"
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -6656,7 +4995,6 @@
         "url": "https://dotenvx.com"
       }
     },
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -6687,28 +5025,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-<<<<<<< HEAD
-    "node_modules/ejs": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
-      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jake": "^10.8.5"
-      },
-      "bin": {
-        "ejs": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/electron-to-chromium": {
-      "version": "1.5.141",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.141.tgz",
-      "integrity": "sha512-qS+qH9oqVYc1ooubTiB9l904WVyM6qNYxtOEEGReoZXw3xlqeYdFr5GclNzbkAufWgwWLEPoDi3d9MoRwwIjGw==",
-=======
     "node_modules/effect": {
       "version": "3.18.4",
       "resolved": "https://registry.npmjs.org/effect/-/effect-3.18.4.tgz",
@@ -6721,10 +5037,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.267",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
-      "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+      "version": "1.5.302",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
+      "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
       "dev": true,
       "license": "ISC"
     },
@@ -6748,12 +5063,6 @@
       "dev": true,
       "license": "MIT"
     },
-<<<<<<< HEAD
-    "node_modules/entities": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.0.tgz",
-      "integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==",
-=======
     "node_modules/empathic": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
@@ -6768,7 +5077,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -6779,15 +5087,9 @@
       }
     },
     "node_modules/error-ex": {
-<<<<<<< HEAD
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-=======
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
       "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6795,15 +5097,9 @@
       }
     },
     "node_modules/es-abstract": {
-<<<<<<< HEAD
-      "version": "1.23.9",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.9.tgz",
-      "integrity": "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA==",
-=======
       "version": "1.24.1",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
       "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6811,31 +5107,18 @@
         "arraybuffer.prototype.slice": "^1.0.4",
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.8",
-<<<<<<< HEAD
-        "call-bound": "^1.0.3",
-=======
         "call-bound": "^1.0.4",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         "data-view-buffer": "^1.0.2",
         "data-view-byte-length": "^1.0.2",
         "data-view-byte-offset": "^1.0.1",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
-<<<<<<< HEAD
-        "es-object-atoms": "^1.0.0",
-        "es-set-tostringtag": "^2.1.0",
-        "es-to-primitive": "^1.3.0",
-        "function.prototype.name": "^1.1.8",
-        "get-intrinsic": "^1.2.7",
-        "get-proto": "^1.0.0",
-=======
         "es-object-atoms": "^1.1.1",
         "es-set-tostringtag": "^2.1.0",
         "es-to-primitive": "^1.3.0",
         "function.prototype.name": "^1.1.8",
         "get-intrinsic": "^1.3.0",
         "get-proto": "^1.0.1",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         "get-symbol-description": "^1.1.0",
         "globalthis": "^1.0.4",
         "gopd": "^1.2.0",
@@ -6847,19 +5130,6 @@
         "is-array-buffer": "^3.0.5",
         "is-callable": "^1.2.7",
         "is-data-view": "^1.0.2",
-<<<<<<< HEAD
-        "is-regex": "^1.2.1",
-        "is-shared-array-buffer": "^1.0.4",
-        "is-string": "^1.1.1",
-        "is-typed-array": "^1.1.15",
-        "is-weakref": "^1.1.0",
-        "math-intrinsics": "^1.1.0",
-        "object-inspect": "^1.13.3",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.7",
-        "own-keys": "^1.0.1",
-        "regexp.prototype.flags": "^1.5.3",
-=======
         "is-negative-zero": "^2.0.3",
         "is-regex": "^1.2.1",
         "is-set": "^2.0.3",
@@ -6873,15 +5143,11 @@
         "object.assign": "^4.1.7",
         "own-keys": "^1.0.1",
         "regexp.prototype.flags": "^1.5.4",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         "safe-array-concat": "^1.1.3",
         "safe-push-apply": "^1.0.0",
         "safe-regex-test": "^1.1.0",
         "set-proto": "^1.0.0",
-<<<<<<< HEAD
-=======
         "stop-iteration-iterator": "^1.1.0",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         "string.prototype.trim": "^1.2.10",
         "string.prototype.trimend": "^1.0.9",
         "string.prototype.trimstart": "^1.0.8",
@@ -6890,11 +5156,7 @@
         "typed-array-byte-offset": "^1.0.4",
         "typed-array-length": "^1.0.7",
         "unbox-primitive": "^1.1.0",
-<<<<<<< HEAD
-        "which-typed-array": "^1.1.18"
-=======
         "which-typed-array": "^1.1.19"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       },
       "engines": {
         "node": ">= 0.4"
@@ -6922,28 +5184,13 @@
       }
     },
     "node_modules/es-iterator-helpers": {
-<<<<<<< HEAD
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.1.tgz",
-      "integrity": "sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==",
-=======
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.2.tgz",
       "integrity": "sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
-<<<<<<< HEAD
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.6",
-        "es-errors": "^1.3.0",
-        "es-set-tostringtag": "^2.0.3",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.6",
-=======
         "call-bound": "^1.0.4",
         "define-properties": "^1.2.1",
         "es-abstract": "^1.24.1",
@@ -6951,18 +5198,13 @@
         "es-set-tostringtag": "^2.1.0",
         "function-bind": "^1.1.2",
         "get-intrinsic": "^1.3.0",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         "globalthis": "^1.0.4",
         "gopd": "^1.2.0",
         "has-property-descriptors": "^1.0.2",
         "has-proto": "^1.2.0",
         "has-symbols": "^1.1.0",
         "internal-slot": "^1.1.0",
-<<<<<<< HEAD
-        "iterator.prototype": "^1.1.4",
-=======
         "iterator.prototype": "^1.1.5",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         "safe-array-concat": "^1.1.3"
       },
       "engines": {
@@ -7027,63 +5269,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-<<<<<<< HEAD
-    "node_modules/esbuild": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.3.tgz",
-      "integrity": "sha512-qKA6Pvai73+M2FtftpNKRxJ78GIjmFXFxd/1DVBqGo/qNhLSfv+G12n9pNoWdytJC8U00TrViOwpjT0zgqQS8Q==",
-      "devOptional": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.3",
-        "@esbuild/android-arm": "0.25.3",
-        "@esbuild/android-arm64": "0.25.3",
-        "@esbuild/android-x64": "0.25.3",
-        "@esbuild/darwin-arm64": "0.25.3",
-        "@esbuild/darwin-x64": "0.25.3",
-        "@esbuild/freebsd-arm64": "0.25.3",
-        "@esbuild/freebsd-x64": "0.25.3",
-        "@esbuild/linux-arm": "0.25.3",
-        "@esbuild/linux-arm64": "0.25.3",
-        "@esbuild/linux-ia32": "0.25.3",
-        "@esbuild/linux-loong64": "0.25.3",
-        "@esbuild/linux-mips64el": "0.25.3",
-        "@esbuild/linux-ppc64": "0.25.3",
-        "@esbuild/linux-riscv64": "0.25.3",
-        "@esbuild/linux-s390x": "0.25.3",
-        "@esbuild/linux-x64": "0.25.3",
-        "@esbuild/netbsd-arm64": "0.25.3",
-        "@esbuild/netbsd-x64": "0.25.3",
-        "@esbuild/openbsd-arm64": "0.25.3",
-        "@esbuild/openbsd-x64": "0.25.3",
-        "@esbuild/sunos-x64": "0.25.3",
-        "@esbuild/win32-arm64": "0.25.3",
-        "@esbuild/win32-ia32": "0.25.3",
-        "@esbuild/win32-x64": "0.25.3"
-      }
-    },
-    "node_modules/esbuild-register": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.6.0.tgz",
-      "integrity": "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "peerDependencies": {
-        "esbuild": ">=0.12 <1"
-      }
-    },
-=======
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -7136,10 +5321,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-<<<<<<< HEAD
-=======
       "peer": true,
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -7191,15 +5373,6 @@
       }
     },
     "node_modules/eslint-config-next": {
-<<<<<<< HEAD
-      "version": "14.2.28",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.2.28.tgz",
-      "integrity": "sha512-UxJMRQ4uaEdLp3mVQoIbRIlEF0S2rTlyZhI/2yEMVdAWmgFfPY4iJZ68jCbhLvXMnKeHMkmqTGjEhFH5Vm9h+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@next/eslint-plugin-next": "14.2.28",
-=======
       "version": "14.2.35",
       "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.2.35.tgz",
       "integrity": "sha512-BpLsv01UisH193WyT/1lpHqq5iJ/Orfz9h/NOOlAmTUq4GY349PextQ62K4XpnaM9supeiEn3TaOTeQO07gURg==",
@@ -7207,7 +5380,6 @@
       "license": "MIT",
       "dependencies": {
         "@next/eslint-plugin-next": "14.2.35",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         "@rushstack/eslint-patch": "^1.3.3",
         "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
@@ -7286,15 +5458,9 @@
       }
     },
     "node_modules/eslint-module-utils": {
-<<<<<<< HEAD
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.0.tgz",
-      "integrity": "sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==",
-=======
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
       "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7320,31 +5486,13 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-<<<<<<< HEAD
-      "version": "2.31.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
-      "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
-=======
       "version": "2.32.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
-<<<<<<< HEAD
-        "array-includes": "^3.1.8",
-        "array.prototype.findlastindex": "^1.2.5",
-        "array.prototype.flat": "^1.3.2",
-        "array.prototype.flatmap": "^1.3.2",
-        "debug": "^3.2.7",
-        "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.9",
-        "eslint-module-utils": "^2.12.0",
-        "hasown": "^2.0.2",
-        "is-core-module": "^2.15.1",
-=======
         "array-includes": "^3.1.9",
         "array.prototype.findlastindex": "^1.2.6",
         "array.prototype.flat": "^1.3.3",
@@ -7355,20 +5503,13 @@
         "eslint-module-utils": "^2.12.1",
         "hasown": "^2.0.2",
         "is-core-module": "^2.16.1",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         "is-glob": "^4.0.3",
         "minimatch": "^3.1.2",
         "object.fromentries": "^2.0.8",
         "object.groupby": "^1.0.3",
-<<<<<<< HEAD
-        "object.values": "^1.2.0",
-        "semver": "^6.3.1",
-        "string.prototype.trimend": "^1.0.8",
-=======
         "object.values": "^1.2.1",
         "semver": "^6.3.1",
         "string.prototype.trimend": "^1.0.9",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         "tsconfig-paths": "^3.15.0"
       },
       "engines": {
@@ -7511,18 +5652,24 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/resolve": {
-      "version": "2.0.0-next.5",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
-      "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
+      "version": "2.0.0-next.6",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
+      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.13.0",
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
         "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7601,9 +5748,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -7715,8 +5862,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/exsolve": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
@@ -7747,7 +5892,6 @@
         "node": ">=8.0.0"
       }
     },
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -7755,15 +5899,9 @@
       "license": "MIT"
     },
     "node_modules/fast-equals": {
-<<<<<<< HEAD
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
-      "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
-=======
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
       "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -7812,9 +5950,9 @@
       "license": "MIT"
     },
     "node_modules/fastq": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -7843,42 +5981,6 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-<<<<<<< HEAD
-    "node_modules/filelist": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
-      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.0.1"
-      }
-    },
-    "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-=======
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -7931,15 +6033,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-<<<<<<< HEAD
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-=======
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
       "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "funding": [
         {
           "type": "individual",
@@ -7990,24 +6086,15 @@
       }
     },
     "node_modules/form-data": {
-<<<<<<< HEAD
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
-=======
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-<<<<<<< HEAD
-=======
         "hasown": "^2.0.2",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -8076,8 +6163,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/generator-function": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
@@ -8088,7 +6173,6 @@
         "node": ">= 0.4"
       }
     },
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -8188,15 +6272,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-<<<<<<< HEAD
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.0.tgz",
-      "integrity": "sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==",
-=======
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
-      "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8206,8 +6284,6 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/giget": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
@@ -8226,11 +6302,11 @@
         "giget": "dist/cli.mjs"
       }
     },
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/glob": {
       "version": "10.3.10",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
       "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -8263,30 +6339,37 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
+      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/glob/node_modules/brace-expansion": {
-<<<<<<< HEAD
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-=======
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
+      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
+      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -8329,15 +6412,9 @@
       }
     },
     "node_modules/goober": {
-<<<<<<< HEAD
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
-      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
-=======
       "version": "2.1.18",
       "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.18.tgz",
       "integrity": "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "license": "MIT",
       "peerDependencies": {
         "csstype": "^3.0.10"
@@ -8368,8 +6445,6 @@
       "dev": true,
       "license": "MIT"
     },
-<<<<<<< HEAD
-=======
     "node_modules/handlebars": {
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
@@ -8392,7 +6467,6 @@
         "uglify-js": "^3.1.4"
       }
     },
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -8549,8 +6623,6 @@
         "node": ">=10.17.0"
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/iceberg-js": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
@@ -8560,7 +6632,6 @@
         "node": ">=20.0.0"
       }
     },
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -8904,16 +6975,6 @@
       }
     },
     "node_modules/is-generator-function": {
-<<<<<<< HEAD
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
-      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "get-proto": "^1.0.0",
-=======
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
       "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
@@ -8923,7 +6984,6 @@
         "call-bound": "^1.0.4",
         "generator-function": "^2.0.0",
         "get-proto": "^1.0.1",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         "has-tostringtag": "^1.0.2",
         "safe-regex-test": "^1.1.0"
       },
@@ -8959,8 +7019,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
@@ -8974,7 +7032,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -9248,15 +7305,9 @@
       }
     },
     "node_modules/istanbul-reports": {
-<<<<<<< HEAD
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
-      "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
-=======
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
       "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -9304,38 +7355,13 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
-<<<<<<< HEAD
-    "node_modules/jake": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
-      "integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "async": "^3.2.3",
-        "chalk": "^4.0.2",
-        "filelist": "^1.0.4",
-        "minimatch": "^3.1.2"
-      },
-      "bin": {
-        "jake": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-=======
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-<<<<<<< HEAD
-=======
       "peer": true,
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -9536,7 +7562,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -10079,7 +8105,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -10301,15 +8327,6 @@
       }
     },
     "node_modules/jiti": {
-<<<<<<< HEAD
-      "version": "1.21.7",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
-      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jiti": "bin/jiti.js"
-=======
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
@@ -10317,7 +8334,6 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       }
     },
     "node_modules/js-tokens": {
@@ -10327,15 +8343,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-<<<<<<< HEAD
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-=======
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10391,36 +8401,6 @@
         }
       }
     },
-<<<<<<< HEAD
-    "node_modules/jsdom/node_modules/tr46": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/jsdom/node_modules/whatwg-url": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "^3.0.0",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-=======
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -10476,21 +8456,12 @@
       }
     },
     "node_modules/jsonwebtoken": {
-<<<<<<< HEAD
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "jws": "^3.2.2",
-=======
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
       "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
       "license": "MIT",
       "dependencies": {
         "jws": "^4.0.1",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         "lodash.includes": "^4.3.0",
         "lodash.isboolean": "^3.0.3",
         "lodash.isinteger": "^4.0.4",
@@ -10523,41 +8494,23 @@
       }
     },
     "node_modules/jwa": {
-<<<<<<< HEAD
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
-=======
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
       "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "license": "MIT",
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         "ecdsa-sig-formatter": "1.0.11",
         "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/jws": {
-<<<<<<< HEAD
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-      "license": "MIT",
-      "dependencies": {
-        "jwa": "^1.4.1",
-=======
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
       "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
       "license": "MIT",
       "dependencies": {
         "jwa": "^2.0.1",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         "safe-buffer": "^5.0.1"
       }
     },
@@ -10668,9 +8621,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
@@ -10766,10 +8719,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-<<<<<<< HEAD
-      "peer": true,
-=======
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -10887,9 +8836,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -10910,11 +8859,11 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -10956,15 +8905,9 @@
       }
     },
     "node_modules/napi-postinstall": {
-<<<<<<< HEAD
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.1.5.tgz",
-      "integrity": "sha512-HI5bHONOUYqV+FJvueOSgjRxHTLB25a3xIv59ugAxFe7xRNbW96hyYbMbsKzl+QvFV9mN/SrtHwiU+vYhMwA7Q==",
-=======
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
       "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -10984,8 +8927,6 @@
       "dev": true,
       "license": "MIT"
     },
-<<<<<<< HEAD
-=======
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -10993,7 +8934,6 @@
       "dev": true,
       "license": "MIT"
     },
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/network-speed": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/network-speed/-/network-speed-2.1.1.tgz",
@@ -11001,21 +8941,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-<<<<<<< HEAD
-      "version": "14.2.28",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.28.tgz",
-      "integrity": "sha512-QLEIP/kYXynIxtcKB6vNjtWLVs3Y4Sb+EClTC/CSVzdLD1gIuItccpu/n1lhmduffI32iPGEK2cLLxxt28qgYA==",
-      "license": "MIT",
-      "dependencies": {
-        "@next/env": "14.2.28",
-=======
       "version": "14.2.35",
       "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
       "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
       "license": "MIT",
       "dependencies": {
         "@next/env": "14.2.35",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
@@ -11030,17 +8961,6 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-<<<<<<< HEAD
-        "@next/swc-darwin-arm64": "14.2.28",
-        "@next/swc-darwin-x64": "14.2.28",
-        "@next/swc-linux-arm64-gnu": "14.2.28",
-        "@next/swc-linux-arm64-musl": "14.2.28",
-        "@next/swc-linux-x64-gnu": "14.2.28",
-        "@next/swc-linux-x64-musl": "14.2.28",
-        "@next/swc-win32-arm64-msvc": "14.2.28",
-        "@next/swc-win32-ia32-msvc": "14.2.28",
-        "@next/swc-win32-x64-msvc": "14.2.28"
-=======
         "@next/swc-darwin-arm64": "14.2.33",
         "@next/swc-darwin-x64": "14.2.33",
         "@next/swc-linux-arm64-gnu": "14.2.33",
@@ -11050,7 +8970,6 @@
         "@next/swc-win32-arm64-msvc": "14.2.33",
         "@next/swc-win32-ia32-msvc": "14.2.33",
         "@next/swc-win32-x64-msvc": "14.2.33"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -11122,8 +9041,35 @@
         }
       }
     },
-<<<<<<< HEAD
-=======
+    "node_modules/node-exports-info": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
+      "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.flatmap": "^1.3.3",
+        "es-errors": "^1.3.0",
+        "object.entries": "^1.1.9",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/node-exports-info/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/node-fetch-native": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
@@ -11131,7 +9077,6 @@
       "devOptional": true,
       "license": "MIT"
     },
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -11140,15 +9085,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-<<<<<<< HEAD
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
-=======
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT"
     },
@@ -11176,14 +9115,6 @@
       }
     },
     "node_modules/nwsapi": {
-<<<<<<< HEAD
-      "version": "2.2.20",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
-      "integrity": "sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==",
-      "dev": true,
-      "license": "MIT"
-    },
-=======
       "version": "2.2.23",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
       "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
@@ -11191,26 +9122,30 @@
       "license": "MIT"
     },
     "node_modules/nypm": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.2.tgz",
-      "integrity": "sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
+      "integrity": "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "citty": "^0.1.6",
-        "consola": "^3.4.2",
+        "citty": "^0.2.0",
         "pathe": "^2.0.3",
-        "pkg-types": "^2.3.0",
-        "tinyexec": "^1.0.1"
+        "tinyexec": "^1.0.2"
       },
       "bin": {
         "nypm": "dist/cli.mjs"
       },
       "engines": {
-        "node": "^14.16.0 || >=16.10.0"
+        "node": ">=18"
       }
     },
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+    "node_modules/nypm/node_modules/citty": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.1.tgz",
+      "integrity": "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -11343,8 +9278,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
@@ -11352,7 +9285,6 @@
       "devOptional": true,
       "license": "MIT"
     },
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -11563,8 +9495,6 @@
       "dev": true,
       "license": "ISC"
     },
-<<<<<<< HEAD
-=======
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -11579,7 +9509,6 @@
       "devOptional": true,
       "license": "MIT"
     },
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -11687,8 +9616,6 @@
         "node": ">=8"
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/pkg-types": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
@@ -11701,7 +9628,6 @@
         "pathe": "^2.0.3"
       }
     },
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -11713,15 +9639,9 @@
       }
     },
     "node_modules/postcss": {
-<<<<<<< HEAD
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
-=======
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "funding": [
         {
@@ -11738,14 +9658,9 @@
         }
       ],
       "license": "MIT",
-<<<<<<< HEAD
-      "dependencies": {
-        "nanoid": "^3.3.8",
-=======
       "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -11772,12 +9687,6 @@
       }
     },
     "node_modules/postcss-js": {
-<<<<<<< HEAD
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
-      "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
-      "dev": true,
-=======
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
       "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
@@ -11792,7 +9701,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "license": "MIT",
       "dependencies": {
         "camelcase-css": "^2.0.1"
@@ -11800,19 +9708,10 @@
       "engines": {
         "node": "^12 || ^14 || >= 16"
       },
-<<<<<<< HEAD
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      },
-=======
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "peerDependencies": {
         "postcss": "^8.4.21"
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/postcss-load-config": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
@@ -11856,7 +9755,6 @@
         }
       }
     },
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/postcss-nested": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
@@ -11920,10 +9818,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-<<<<<<< HEAD
-      "peer": true,
-=======
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -11939,10 +9833,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-<<<<<<< HEAD
-      "peer": true,
-=======
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "engines": {
         "node": ">=10"
       },
@@ -11955,35 +9845,19 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-<<<<<<< HEAD
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/prisma": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.6.0.tgz",
-      "integrity": "sha512-SYCUykz+1cnl6Ugd8VUvtTQq5+j1Q7C0CtzKPjQ8JyA2ALh0EEJkMCS+KgdnvKW1lrxjtjCyJSHOOT236mENYg==",
-      "devOptional": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@prisma/config": "6.6.0",
-        "@prisma/engines": "6.6.0"
-=======
       "license": "MIT"
     },
     "node_modules/prisma": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.1.tgz",
-      "integrity": "sha512-XRfmGzh6gtkc/Vq3LqZJcS2884dQQW3UhPo6jNRoiTW95FFQkXFg8vkYEy6og+Pyv0aY7zRQ7Wn1Cvr56XjhQQ==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.2.tgz",
+      "integrity": "sha512-XTKeKxtQElcq3U9/jHyxSPgiRgeYDKxWTPOf6NkXA0dNj5j40MfEsZkMbyNpwDWCUv7YBFUl7I2VK/6ALbmhEg==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@prisma/config": "6.19.1",
-        "@prisma/engines": "6.19.1"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+        "@prisma/config": "6.19.2",
+        "@prisma/engines": "6.19.2"
       },
       "bin": {
         "prisma": "build/index.js"
@@ -11991,12 +9865,6 @@
       "engines": {
         "node": ">=18.18"
       },
-<<<<<<< HEAD
-      "optionalDependencies": {
-        "fsevents": "2.3.3"
-      },
-=======
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "peerDependencies": {
         "typescript": ">=5.1.0"
       },
@@ -12070,11 +9938,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
       "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
-<<<<<<< HEAD
-      "dev": true,
-=======
       "devOptional": true,
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "funding": [
         {
           "type": "individual",
@@ -12114,8 +9978,6 @@
       ],
       "license": "MIT"
     },
-<<<<<<< HEAD
-=======
     "node_modules/rc9": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
@@ -12127,16 +9989,12 @@
         "destr": "^2.0.3"
       }
     },
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-<<<<<<< HEAD
-=======
       "peer": true,
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -12149,10 +10007,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-<<<<<<< HEAD
-=======
       "peer": true,
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -12162,15 +10017,9 @@
       }
     },
     "node_modules/react-hot-toast": {
-<<<<<<< HEAD
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.5.2.tgz",
-      "integrity": "sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw==",
-=======
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
       "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.3",
@@ -12185,15 +10034,9 @@
       }
     },
     "node_modules/react-is": {
-<<<<<<< HEAD
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
-      "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
-=======
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.3.tgz",
-      "integrity": "sha512-qJNJfu81ByyabuG7hPFEbXqNcWSU3+eVus+KJs+0ncpGfMyYdvSmxiJxbWR65lYi1I+/0HBcliO029gc4F+PnA==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
+      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
       "license": "MIT"
     },
     "node_modules/react-lifecycles-compat": {
@@ -12272,15 +10115,9 @@
       }
     },
     "node_modules/react-virtuoso": {
-<<<<<<< HEAD
-      "version": "4.12.6",
-      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.12.6.tgz",
-      "integrity": "sha512-bfvS6aCL1ehXmq39KRiz/vxznGUbtA27I5I24TYCe1DhMf84O3aVNCIwrSjYQjkJGJGzY46ihdN8WkYlemuhMQ==",
-=======
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.17.0.tgz",
-      "integrity": "sha512-od3pi2v13v31uzn5zPXC2u3ouISFCVhjFVFch2VvS2Cx7pWA2F1aJa3XhNTN2F07M3lhfnMnsmGeH+7wZICr7w==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.18.1.tgz",
+      "integrity": "sha512-KF474cDwaSb9+SJ380xruBB4P+yGWcVkcu26HtMqYNMTYlYbrNy8vqMkE+GpAApPPufJqgOLMoWMFG/3pJMXUA==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16 || >=17 || >= 18 || >= 19",
@@ -12298,24 +10135,6 @@
       }
     },
     "node_modules/readdirp": {
-<<<<<<< HEAD
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/recharts": {
-      "version": "2.15.3",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.3.tgz",
-      "integrity": "sha512-EdOPzTwcFSuqtvkDoaM5ws/Km1+WTAO2eizL7rqiG0V2UVhTnz0m7J2i0CjVPUCdEkZImaWvXLbZDS2H5t6GFQ==",
-=======
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
@@ -12333,7 +10152,6 @@
       "version": "2.15.4",
       "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
       "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0",
@@ -12414,15 +10232,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-<<<<<<< HEAD
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "license": "MIT"
-    },
-=======
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -12462,15 +10271,6 @@
       "license": "MIT"
     },
     "node_modules/resolve": {
-<<<<<<< HEAD
-      "version": "1.22.10",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.16.0",
-=======
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
       "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
@@ -12478,7 +10278,6 @@
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.1",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -12576,7 +10375,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -12722,15 +10521,9 @@
       }
     },
     "node_modules/semver": {
-<<<<<<< HEAD
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-=======
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -12984,8 +10777,6 @@
         "node": ">=8"
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -13000,7 +10791,6 @@
         "node": ">= 0.4"
       }
     },
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/streamsearch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
@@ -13065,15 +10855,9 @@
       "license": "MIT"
     },
     "node_modules/string-width/node_modules/ansi-regex": {
-<<<<<<< HEAD
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-=======
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13084,15 +10868,9 @@
       }
     },
     "node_modules/string-width/node_modules/strip-ansi": {
-<<<<<<< HEAD
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-=======
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13292,15 +11070,9 @@
       }
     },
     "node_modules/styled-jsx": {
-<<<<<<< HEAD
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
-      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
-=======
       "version": "5.1.7",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.7.tgz",
       "integrity": "sha512-HPLmEIYprxCeWDMLYiaaAhsV3yGfIlCqzuVOybE6fjF3SUJmH67nCoMDO+nAvHNHo46OfvpCNu4Rcue82dMNFg==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "license": "MIT",
       "dependencies": {
         "client-only": "0.0.1"
@@ -13327,31 +11099,18 @@
       "license": "MIT"
     },
     "node_modules/sucrase": {
-<<<<<<< HEAD
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
-      "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
-=======
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
       "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
         "commander": "^4.0.0",
-<<<<<<< HEAD
-        "glob": "^10.3.10",
-        "lines-and-columns": "^1.1.6",
-        "mz": "^2.7.0",
-        "pirates": "^4.0.1",
-=======
         "lines-and-columns": "^1.1.6",
         "mz": "^2.7.0",
         "pirates": "^4.0.1",
         "tinyglobby": "^0.2.11",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         "ts-interface-checker": "^0.1.9"
       },
       "bin": {
@@ -13405,15 +11164,9 @@
       }
     },
     "node_modules/swiper": {
-<<<<<<< HEAD
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.2.6.tgz",
-      "integrity": "sha512-8aXpYKtjy3DjcbzZfz+/OX/GhcU5h+looA6PbAzHMZT6ESSycSp9nAjPCenczgJyslV+rUGse64LMGpWE3PX9Q==",
-=======
       "version": "11.2.10",
       "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.2.10.tgz",
       "integrity": "sha512-RMeVUUjTQH+6N3ckimK93oxz6Sn5la4aDlgPzB+rBrG/smPdCTicXyhxa+woIpopz+jewEloiEE3lKo1h9w2YQ==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "funding": [
         {
           "type": "patreon",
@@ -13430,23 +11183,13 @@
       }
     },
     "node_modules/swr": {
-<<<<<<< HEAD
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.3.tgz",
-      "integrity": "sha512-dshNvs3ExOqtZ6kJBaAsabhPdHyeY4P2cKwRCniDVifBMoG/SVI7tfLWqPXriVspf2Rg4tPzXJTnwaihIeFw2A==",
-      "license": "MIT",
-      "dependencies": {
-        "dequal": "^2.0.3",
-        "use-sync-external-store": "^1.4.0"
-=======
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.8.tgz",
-      "integrity": "sha512-gaCPRVoMq8WGDcWj9p4YWzCMPHzE0WNl6W8ADIx9c3JBEIdMkJGMzW+uzXvxHMltwcYACr9jP+32H8/hgwMR7w==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.0.tgz",
+      "integrity": "sha512-sUlC20T8EOt1pHmDiqueUWMmRRX03W7w5YxovWX7VR2KHEPCTMly85x05vpkP5i6Bu4h44ePSMD9Tc+G2MItFw==",
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3",
         "use-sync-external-store": "^1.6.0"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       },
       "peerDependencies": {
         "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -13460,20 +11203,12 @@
       "license": "MIT"
     },
     "node_modules/tailwindcss": {
-<<<<<<< HEAD
-      "version": "3.4.17",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
-      "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
-      "dev": true,
-      "license": "MIT",
-=======
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -13483,11 +11218,7 @@
         "fast-glob": "^3.3.2",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
-<<<<<<< HEAD
-        "jiti": "^1.21.6",
-=======
         "jiti": "^1.21.7",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         "lilconfig": "^3.1.3",
         "micromatch": "^4.0.8",
         "normalize-path": "^3.0.0",
@@ -13496,11 +11227,7 @@
         "postcss": "^8.4.47",
         "postcss-import": "^15.1.0",
         "postcss-js": "^4.0.1",
-<<<<<<< HEAD
-        "postcss-load-config": "^4.0.2",
-=======
         "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         "postcss-nested": "^6.2.0",
         "postcss-selector-parser": "^6.1.2",
         "resolve": "^1.22.8",
@@ -13514,42 +11241,6 @@
         "node": ">=14.0.0"
       }
     },
-<<<<<<< HEAD
-    "node_modules/tailwindcss/node_modules/postcss-load-config": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
-      "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "lilconfig": "^3.0.0",
-        "yaml": "^2.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      },
-      "peerDependencies": {
-        "postcss": ">=8.0.9",
-        "ts-node": ">=9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "postcss": {
-          "optional": true
-        },
-        "ts-node": {
-          "optional": true
-        }
-=======
     "node_modules/tailwindcss/node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -13609,7 +11300,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       }
     },
     "node_modules/test-exclude": {
@@ -13631,7 +11321,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -13685,17 +11375,6 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
-<<<<<<< HEAD
-    "node_modules/tinyglobby": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
-      "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
-=======
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -13715,7 +11394,6 @@
       "dependencies": {
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3"
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       },
       "engines": {
         "node": ">=12.0.0"
@@ -13725,13 +11403,6 @@
       }
     },
     "node_modules/tinyglobby/node_modules/fdir": {
-<<<<<<< HEAD
-      "version": "6.4.4",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
-      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
-      "dev": true,
-      "license": "MIT",
-=======
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
@@ -13740,7 +11411,6 @@
       "engines": {
         "node": ">=12.0.0"
       },
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -13751,20 +11421,12 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-<<<<<<< HEAD
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
-      "license": "MIT",
-=======
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "engines": {
         "node": ">=12"
       },
@@ -13808,12 +11470,6 @@
       }
     },
     "node_modules/tr46": {
-<<<<<<< HEAD
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-=======
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
       "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
@@ -13825,12 +11481,11 @@
       "engines": {
         "node": ">=12"
       }
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     },
     "node_modules/ts-api-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13847,29 +11502,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/ts-jest": {
-<<<<<<< HEAD
-      "version": "29.3.2",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.3.2.tgz",
-      "integrity": "sha512-bJJkrWc6PjFVz5g2DGCNUo8z7oFEYaz1xP1NpeDU7KNLMWPpEyV8Chbpkn8xjzgRDpQhnGMyvyldoL7h8JXyug==",
-=======
       "version": "29.4.6",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
       "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
-<<<<<<< HEAD
-        "ejs": "^3.1.10",
-        "fast-json-stable-stringify": "^2.1.0",
-        "jest-util": "^29.0.0",
-        "json5": "^2.2.3",
-        "lodash.memoize": "^4.1.2",
-        "make-error": "^1.3.6",
-        "semver": "^7.7.1",
-        "type-fest": "^4.39.1",
-=======
         "fast-json-stable-stringify": "^2.1.0",
         "handlebars": "^4.7.8",
         "json5": "^2.2.3",
@@ -13877,7 +11516,6 @@
         "make-error": "^1.3.6",
         "semver": "^7.7.3",
         "type-fest": "^4.41.0",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         "yargs-parser": "^21.1.1"
       },
       "bin": {
@@ -13888,18 +11526,11 @@
       },
       "peerDependencies": {
         "@babel/core": ">=7.0.0-beta.0 <8",
-<<<<<<< HEAD
-        "@jest/transform": "^29.0.0",
-        "@jest/types": "^29.0.0",
-        "babel-jest": "^29.0.0",
-        "jest": "^29.0.0",
-=======
         "@jest/transform": "^29.0.0 || ^30.0.0",
         "@jest/types": "^29.0.0 || ^30.0.0",
         "babel-jest": "^29.0.0 || ^30.0.0",
         "jest": "^29.0.0 || ^30.0.0",
         "jest-util": "^29.0.0 || ^30.0.0",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         "typescript": ">=4.3 <6"
       },
       "peerDependenciesMeta": {
@@ -13917,25 +11548,16 @@
         },
         "esbuild": {
           "optional": true
-<<<<<<< HEAD
-=======
         },
         "jest-util": {
           "optional": true
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
         }
       }
     },
     "node_modules/ts-jest/node_modules/type-fest": {
-<<<<<<< HEAD
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.40.0.tgz",
-      "integrity": "sha512-ABHZ2/tS2JkvH1PEjxFDTUWC8dB5OsIGZP4IFLhR293GqT5Y5qB1WwL2kMPYhQW9DVgVD8Hd7I8gjwPIf5GFkw==",
-=======
       "version": "4.41.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
       "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
@@ -14102,20 +11724,12 @@
       }
     },
     "node_modules/typescript": {
-<<<<<<< HEAD
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "devOptional": true,
-      "license": "Apache-2.0",
-=======
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "peer": true,
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14124,8 +11738,6 @@
         "node": ">=14.17"
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/uglify-js": {
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
@@ -14140,7 +11752,6 @@
         "node": ">=0.8.0"
       }
     },
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -14161,15 +11772,9 @@
       }
     },
     "node_modules/undici-types": {
-<<<<<<< HEAD
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-=======
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "license": "MIT"
     },
     "node_modules/universalify": {
@@ -14183,50 +11788,13 @@
       }
     },
     "node_modules/unrs-resolver": {
-<<<<<<< HEAD
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.6.6.tgz",
-      "integrity": "sha512-IjvN/Nw9ogxlKbZY/YNqlYqvguKmyERCl7BHvFt3sDBRd/+VLfVHooQ03VbMUW9Hqh/lTY4MYwZHQNqBjkawhg==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
       "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-<<<<<<< HEAD
-        "napi-postinstall": "^0.1.5"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/JounQin"
-      },
-      "optionalDependencies": {
-        "@unrs/resolver-binding-darwin-arm64": "1.6.6",
-        "@unrs/resolver-binding-darwin-x64": "1.6.6",
-        "@unrs/resolver-binding-freebsd-x64": "1.6.6",
-        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.6.6",
-        "@unrs/resolver-binding-linux-arm-musleabihf": "1.6.6",
-        "@unrs/resolver-binding-linux-arm64-gnu": "1.6.6",
-        "@unrs/resolver-binding-linux-arm64-musl": "1.6.6",
-        "@unrs/resolver-binding-linux-ppc64-gnu": "1.6.6",
-        "@unrs/resolver-binding-linux-riscv64-gnu": "1.6.6",
-        "@unrs/resolver-binding-linux-riscv64-musl": "1.6.6",
-        "@unrs/resolver-binding-linux-s390x-gnu": "1.6.6",
-        "@unrs/resolver-binding-linux-x64-gnu": "1.6.6",
-        "@unrs/resolver-binding-linux-x64-musl": "1.6.6",
-        "@unrs/resolver-binding-wasm32-wasi": "1.6.6",
-        "@unrs/resolver-binding-win32-arm64-msvc": "1.6.6",
-        "@unrs/resolver-binding-win32-ia32-msvc": "1.6.6",
-        "@unrs/resolver-binding-win32-x64-msvc": "1.6.6"
-      }
-    },
-    "node_modules/update-browserslist-db": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
-=======
         "napi-postinstall": "^0.3.0"
       },
       "funding": {
@@ -14258,7 +11826,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "funding": [
         {
@@ -14308,15 +11875,9 @@
       }
     },
     "node_modules/use-sync-external-store": {
-<<<<<<< HEAD
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
-      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
-=======
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -14431,6 +11992,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
       "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14451,23 +12013,6 @@
       }
     },
     "node_modules/whatwg-url": {
-<<<<<<< HEAD
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
-    "node_modules/whatwg-url/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-=======
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
       "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
@@ -14481,7 +12026,6 @@
         "node": ">=12"
       }
     },
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -14566,9 +12110,9 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
-      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14597,8 +12141,6 @@
         "node": ">=0.10.0"
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -14606,7 +12148,6 @@
       "dev": true,
       "license": "MIT"
     },
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
@@ -14667,15 +12208,9 @@
       }
     },
     "node_modules/wrap-ansi/node_modules/ansi-regex": {
-<<<<<<< HEAD
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-=======
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14686,15 +12221,9 @@
       }
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
-<<<<<<< HEAD
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-=======
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14705,15 +12234,9 @@
       }
     },
     "node_modules/wrap-ansi/node_modules/strip-ansi": {
-<<<<<<< HEAD
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-=======
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14755,15 +12278,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-<<<<<<< HEAD
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
-=======
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -14815,22 +12332,6 @@
       "dev": true,
       "license": "ISC"
     },
-<<<<<<< HEAD
-    "node_modules/yaml": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-=======
->>>>>>> f80fe5e (現在地と店舗位置情報の型定義を追加)
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,6 +46,9 @@ model Cafe {
   thumbnailImage         String            @db.VarChar(255) 
   area                   String
   storeAddress           String  
+  placeId                String?
+  primaryType            String?
+  types                  String[]
   openingTime            String            @db.VarChar(20)
   closingHours           String            @db.VarChar(20)
   closingDays            String

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,10 +45,10 @@ model Cafe {
   cafeName               String            @db.VarChar(100)
   thumbnailImage         String            @db.VarChar(255) 
   area                   String
-  storeAddress           String  
+  storeAddress           String
   placeId                String?
   primaryType            String?
-  types                  String[]
+  types                  String[]  
   openingTime            String            @db.VarChar(20)
   closingHours           String            @db.VarChar(20)
   closingDays            String

--- a/src/_utils/api.ts
+++ b/src/_utils/api.ts
@@ -8,7 +8,7 @@ const isLocalhost = typeof window !== "undefined" && window.location.hostname ==
 
 const api = {
   //requestにまとめてメソッドを共通にする
-  request: async <T>(method: string, endpoint: string, body?: T) => {
+  request: async <Res>(method: string, endpoint: string, body?: Res) => {
 
     const baseUrl = isLocalhost
   ? "http://localhost:3000" // ローカル用APIエンドポイント
@@ -44,7 +44,7 @@ const api = {
   },
   //それぞれのメソッドに、request関数を呼び出す
   get: (endpoint: string) => api.request('GET', endpoint),//GETのみSWRで取得するため、bodyは不要(endpointのみ)
-  post: <T>(endpoint: string, body: T) => api.request('POST', endpoint, body),
+  post: <Req, Res>(endpoint: string, body: Req): Promise<Res> => api.request('POST', endpoint, body),// Request・Response両方に型チェックで安全にする
   put: <T>(endpoint: string, body: T) => api.request('PUT', endpoint, body),
   delete: <T>(endpoint: string, body: T) => api.request('DELETE', endpoint, body),
 };

--- a/src/app/_components/Input.tsx
+++ b/src/app/_components/Input.tsx
@@ -10,6 +10,7 @@ type InputProps = {
   placeholder?: string;
   required?: boolean;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onFocus?: (e: React.FocusEvent<HTMLInputElement>) => void;
   className: string;
 };
 
@@ -21,6 +22,7 @@ export const Input: React.FC<InputProps> = ({
   placeholder,
   required = true,
   onChange,
+  onFocus,
   className,
 }) => {
   return (
@@ -32,6 +34,7 @@ export const Input: React.FC<InputProps> = ({
       placeholder={placeholder}
       required={required}
       onChange={onChange}
+      onFocus={onFocus}
       className={className}
     />
   );

--- a/src/app/_types/Cafe.ts
+++ b/src/app/_types/Cafe.ts
@@ -1,10 +1,14 @@
 import { WifiSpeed,  WifiStability, SeatAvailability } from "@prisma/client";
+import { PlaceCandidate } from "../admin/cafe_submission_form/types/placeCandidate";
 
 export type Cafe = {
   id: number;
   cafeName: string;
   area: string;
   storeAddress: string;
+  placeId?: PlaceCandidate["placeId"];
+  primaryType?: PlaceCandidate["primaryType"];
+  types: PlaceCandidate["types"];
   openingTime?: string;
   closingHours?: string;
   businessHours?: string;

--- a/src/app/_types/Cafe.ts
+++ b/src/app/_types/Cafe.ts
@@ -1,14 +1,13 @@
 import { WifiSpeed,  WifiStability, SeatAvailability } from "@prisma/client";
-import { PlaceCandidate } from "../admin/cafe_submission_form/types/placeCandidate";
 
 export type Cafe = {
   id: number;
   cafeName: string;
   area: string;
   storeAddress: string;
-  placeId?: PlaceCandidate["placeId"];
-  primaryType?: PlaceCandidate["primaryType"];
-  types: PlaceCandidate["types"];
+  placeId?: string;
+  primaryType?: string;
+  types: string[];
   openingTime?: string;
   closingHours?: string;
   businessHours?: string;

--- a/src/app/admin/_components/Button.tsx
+++ b/src/app/admin/_components/Button.tsx
@@ -28,7 +28,7 @@ export const Button: React.FC<ButtonProps> = ({
   const handleClick = (e: React.FormEvent) => {
     if (onClick) {
       onClick(e);
-    }
+    }n
   };
 
   return (

--- a/src/app/admin/_components/Button.tsx
+++ b/src/app/admin/_components/Button.tsx
@@ -28,7 +28,7 @@ export const Button: React.FC<ButtonProps> = ({
   const handleClick = (e: React.FormEvent) => {
     if (onClick) {
       onClick(e);
-    }n
+    }
   };
 
   return (

--- a/src/app/admin/_components/CafePostForm.tsx
+++ b/src/app/admin/_components/CafePostForm.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { FormEvent, useState } from "react";
+import React, { FormEvent, useState, FocusEvent, useMemo } from "react";
 import { Input } from "@/app/_components/Input";
 import { CafeFormFields } from "../_data/cafeFormFields";
 import { CafePostButtons } from "./CafePostButtons";
@@ -12,6 +12,10 @@ import { WifiSpeed, WifiStability, SeatAvailability } from "@prisma/client";
 import useSWR, { mutate } from "swr";
 import api from "@/_utils/api";
 import toast, { Toaster } from "react-hot-toast";
+import { fetchNearbyCandidates } from "../cafe_submission_form/_utils/fetchNearbyCandidates";
+import { PlaceCandidate } from "../cafe_submission_form/types/placeCandidate";
+import { NearbySearchConditionPanel } from "../cafe_submission_form/_components/NearbySearchConditionPanel";
+import { CandidateDropdown } from "../cafe_submission_form/_components/CandidateDropdown";
 import "../../globals.css";
 
 //共通リクエストを使用する
@@ -34,12 +38,17 @@ export const CafePostForm: React.FC<CafeFormStateReturn> = ({
   setFormState,
   onChange,
   clearForm,
+  nearby,
 }) => {
   const [errors, setErrors] = useState<FormErrorsType>({});
   const [clearSignal, setClearSignal] = useState(false);
   const [rating, setRating] = useState(3); // 星評価の状態
   const [errorMessage, setErrorMessage] = useState<string | null>(null); // エラーメッセージ用の状態
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [candidates, setCandidates] = useState<PlaceCandidate[]>([]);
+  const [isOpenCandidates, setIsOpenCandidates] = useState(false);
+  const [isLoadingCandidates, setIsLoadingCandidates] = useState(false);
+  const [isConditionPanelOpen, setIsConditionPanelOpen] = useState(false);
 
   //  SWRを使ったデータ取得
   useSWR("/api/admin/cafe_submission_form", ([url]) => fetcher(url), {
@@ -53,7 +62,7 @@ export const CafePostForm: React.FC<CafeFormStateReturn> = ({
   useSWR(
     formState.storeAddress
       ? `https://maps.googleapis.com/maps/api/geocode/json?address=${encodeURIComponent(
-          formState.storeAddress
+          formState.storeAddress,
         )}&key=${process.env.NEXT_PUBLIC_GOOGLE_MAP_API_KEY}`
       : null,
     fetchGeocode,
@@ -64,7 +73,7 @@ export const CafePostForm: React.FC<CafeFormStateReturn> = ({
           locationCoordinates: coordinates,
         }));
       },
-    }
+    },
   );
 
   const handleSubmit = async (e: FormEvent) => {
@@ -138,7 +147,7 @@ export const CafePostForm: React.FC<CafeFormStateReturn> = ({
 
       // 全体エラー（必須未入力）がある場合だけ、汎用メッセージを出す
       const hasRequiredMissing = Object.values(tempErrors).some(
-        (msg) => msg === "※必須"
+        (msg) => msg === "※必須",
       );
       if (hasRequiredMissing) {
         toast.error("必須項目は入力してください！！");
@@ -152,7 +161,7 @@ export const CafePostForm: React.FC<CafeFormStateReturn> = ({
 
   const convertSelection = (
     option: string,
-    fieldName: string
+    fieldName: string,
   ): WifiSpeed | WifiStability | SeatAvailability | number | boolean | null => {
     console.log(option, fieldName); // デバッグ用ログ
 
@@ -167,7 +176,7 @@ export const CafePostForm: React.FC<CafeFormStateReturn> = ({
       case "wifiSpeed":
         if (!formState.wifiAvailable) {
           setErrorMessage(
-            "Wi-Fiの有無が「無」の場合、Wi-Fi速度を選択できません。"
+            "Wi-Fiの有無が「無」の場合、Wi-Fi速度を選択できません。",
           );
           return null;
         }
@@ -185,7 +194,7 @@ export const CafePostForm: React.FC<CafeFormStateReturn> = ({
       case "wifiStability":
         if (!formState.wifiAvailable) {
           setErrorMessage(
-            "Wi-Fiの有無が「無」の場合、Wi-Fi安定性を選択できません。"
+            "Wi-Fiの有無が「無」の場合、Wi-Fi安定性を選択できません。",
           );
           return null;
         }
@@ -232,6 +241,53 @@ export const CafePostForm: React.FC<CafeFormStateReturn> = ({
     setTimeout(() => setClearSignal(false), 0);
   };
 
+  // 候補選択時の更新処理
+  const handleSelectCandidate = (c: PlaceCandidate) => {
+    setFormState((prev) => ({
+      ...prev,
+      cafeName: c.cafeName,
+      storeAddress: c.storeAddress,
+      locationCoordinates: `${c.locationCoordinates.latitude}, ${c.locationCoordinates.longitude}`,
+    }));
+    setIsOpenCandidates(false);
+  };
+
+  const { params } = nearby;
+  // 現在地取得後、お店住所欄をフォーカスすることで現在地から周辺情報を一覧させる
+  const handleFocus = async (e: FocusEvent<HTMLInputElement>) => {
+    if (e.currentTarget.name !== "storeAddress") return;
+    if (!params) {
+      toast.error("現在地が取得できていません");
+      return;
+    }
+
+    // 既に候補があるなら再取得せず開くだけ(無駄なAPI叩くのを減らすため)
+    if (candidates.length > 0) {
+      setIsOpenCandidates(true);
+      return;
+    }
+
+    try {
+      setIsLoadingCandidates(true);
+      const listCandidate = await fetchNearbyCandidates(params);
+      setCandidates(listCandidate);
+      setIsConditionPanelOpen(true);
+      setIsOpenCandidates(true);
+    } catch (err) {
+      console.log(err);
+      toast.error("周辺候補の取得に失敗しました");
+    } finally {
+      setIsLoadingCandidates(false);
+    }
+  };
+
+  const paramsKey = useMemo(() => JSON.stringify(params ?? null), [params]);
+  React.useEffect(() => {
+    setCandidates([]);
+    setIsOpenCandidates(false);
+    setIsLoadingCandidates(false);
+  }, [paramsKey]);
+
   return (
     <div className="flex flex-col items-center py-40 sm:px-4 sm:text-sm">
       <Toaster position="top-center" reverseOrder={false} />
@@ -252,8 +308,22 @@ export const CafePostForm: React.FC<CafeFormStateReturn> = ({
               placeholder={placeholder}
               onChange={onChange}
               required={required}
+              onFocus={name === "storeAddress" ? handleFocus : undefined}
               className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-3xl focus:ring-blue-500 focus:border-blue-500 block w-full p-5"
             />
+            {name === "storeAddress" && (
+              <>
+                {isConditionPanelOpen && (
+                  <NearbySearchConditionPanel nearby={nearby} />
+                )}
+                <CandidateDropdown
+                  open={isOpenCandidates}
+                  loading={isLoadingCandidates}
+                  candidates={candidates}
+                  onSelect={handleSelectCandidate}
+                />
+              </>
+            )}
           </div>
         ))}
 

--- a/src/app/admin/_components/Modal.tsx
+++ b/src/app/admin/_components/Modal.tsx
@@ -1,19 +1,90 @@
 "use client";
-import React,{ReactNode} from "react";
+import React, { ReactNode } from "react";
 import ReactModal from "react-modal";
-import "../../globals.css";
 
-type Props = {
+type ModalProps = {
   isOpen: boolean;
-  onClose: (e: React.MouseEvent<HTMLElement>) => void;
+  onClose: () => void;
   children: ReactNode;
+
+  // 任意：content / overlay を呼び出し側で自由に上書きできる
+  className?: string;
+  overlayClassName?: string;
+
+  // 任意：アクセシビリティ用
+  contentLabel?: string;
+
+  // 任意：閉じるボタン/ヘッダーが欲しい場合だけ使う
+  title?: string;
+  showCloseButton?: boolean;
 };
 
-export const Modal: React.FC<Props> = ({ isOpen, onClose, children }) => {
+const defaultContentClass = `
+  fixed left-1/2 top-1/2 z-[70]
+  w-[92vw] max-w-md
+  -translate-x-1/2 -translate-y-1/2
+  rounded-2xl bg-white p-6
+  shadow-2xl ring-1 ring-black/5
+  focus:outline-none
+`;
+
+const defaultOverlayClass = `
+  fixed inset-0 z-[60]
+  bg-black/50 backdrop-blur-sm
+  flex items-center justify-center px-4
+`;
+
+export const Modal: React.FC<ModalProps> = ({
+  isOpen,
+  onClose,
+  children,
+  className,
+  overlayClassName,
+  contentLabel = "Modal",
+  title,
+  showCloseButton = false,
+}) => {
   return (
-    <ReactModal isOpen={isOpen} onRequestClose={onClose} ariaHideApp={false}>
-      <div>
-        <button onClick={onClose}>{children}</button>
+    <ReactModal
+      isOpen={isOpen}
+      onRequestClose={onClose}
+      ariaHideApp={false}
+      contentLabel={contentLabel}
+      className={className ?? defaultContentClass}
+      overlayClassName={overlayClassName ?? defaultOverlayClass}
+      shouldCloseOnOverlayClick
+      shouldCloseOnEsc
+    >
+      {/* 汎用性を壊さない：ここで children を button で包まない */}
+      <div className="space-y-4">
+        {(title || showCloseButton) && (
+          <div className="flex items-start justify-between gap-3">
+            {title ? (
+              <h2 className="text-base sm:text-lg font-semibold tracking-tight text-gray-900">
+                {title}
+              </h2>
+            ) : (
+              <span />
+            )}
+
+            {showCloseButton && (
+              <button
+                type="button"
+                onClick={onClose}
+                className="
+                  inline-flex h-9 w-9 items-center justify-center rounded-full
+                  text-gray-500 hover:bg-gray-100 hover:text-gray-700
+                  transition
+                "
+                aria-label="閉じる"
+              >
+                ✕
+              </button>
+            )}
+          </div>
+        )}
+
+        {children}
       </div>
     </ReactModal>
   );

--- a/src/app/admin/_components/ThumbnailHandle.tsx
+++ b/src/app/admin/_components/ThumbnailHandle.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import React, { useState, useEffect } from "react";
 import Image from "next/image";
 import { Button } from "@/app/admin/_components/Button";
@@ -15,9 +16,10 @@ export const ThumbnailHandle: React.FC<{
   isLoading: boolean;
   location: Coordinate | undefined;
   locationError: string | null;
+  reset: () => void;
   getCurrentLocation: () => Promise<Coordinate>;
   setIsSubmitting: (isSubmitting: boolean) => void;
-}> = ({ onImageUpload, initialImage, isLoading, locationError, getCurrentLocation }) => {
+}> = ({ onImageUpload, initialImage, isLoading, locationError, getCurrentLocation, reset }) => {
   const {
     thumbnailImage,
     handleFileChange,
@@ -56,6 +58,11 @@ export const ThumbnailHandle: React.FC<{
     } catch {
       toast.error("現在地取得できませんでした!!");
     }
+  }
+
+  const handleClear = () => {
+    reset();
+    closeModal();
   }
 
   return (
@@ -145,12 +152,12 @@ export const ThumbnailHandle: React.FC<{
           <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end pt-2">
             <button
               type="button"
-              onClick={closeModal}
+              onClick={handleClear}
               className="
         inline-flex h-11 items-center justify-center rounded-xl px-4
-        text-sm font-medium text-gray-700
-        ring-1 ring-inset ring-gray-200
-        hover:bg-gray-50 active:bg-gray-100 transition
+        text-sm font-bold text-black
+        ring-1 ring-inset ring-gray-400
+        hover:bg-gray-200 active:bg-gray-100 transition
       "
             >
               キャンセル
@@ -162,7 +169,7 @@ export const ThumbnailHandle: React.FC<{
               className="
         inline-flex h-11 items-center justify-center rounded-xl px-4
         text-sm font-semibold text-white
-        bg-gray-900 hover:bg-gray-800
+        bg-gray-900 hover:bg-gray-600
         shadow-sm active:scale-[0.99] transition
       "
             >

--- a/src/app/admin/_components/ThumbnailHandle.tsx
+++ b/src/app/admin/_components/ThumbnailHandle.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from "react";
 import Image from "next/image";
 import { Button } from "@/app/admin/_components/Button";
+import { Modal } from "./Modal";
 import { useImageHandler } from "@/app/admin/_hooks/useImageHandler";
 import "../../globals.css";
 
@@ -21,6 +22,7 @@ export const ThumbnailHandle: React.FC<{
     measureDownloadSpeed,
   } = useImageHandler(onImageUpload, initialImage, "thumbnail-input");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
 
   //画像がセットされたら、isSubmittingをfalseにする(ボタン表示処理)
   useEffect(() => {
@@ -35,6 +37,9 @@ export const ThumbnailHandle: React.FC<{
     setIsSubmitting(true); // 送信中フラグを設定
     handleAddClick(); // 実際の画像追加処理
   };
+
+  const openModal = () => setIsOpen(true);
+  const closeModal = () => setIsOpen(false);
 
   return (
     <div className="flex flex-col items-center space-y-4">
@@ -103,6 +108,54 @@ export const ThumbnailHandle: React.FC<{
             削除
           </Button>
         </div>
+        <div className="px-3">
+          <Button type="button" variant="secondary" onClick={openModal}>
+            現在地取得
+          </Button>
+        </div>
+        <Modal
+          isOpen={isOpen}
+          onClose={closeModal}
+          title="現在地の取得を許可しますか？"
+          showCloseButton
+        >
+          <p className="text-sm leading-relaxed text-gray-600">
+            近くのカフェを表示するために現在地を使用します。
+            <br />
+            許可しなくても検索は可能です。(手入力)
+          </p>
+
+          <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end pt-2">
+            <button
+              type="button"
+              onClick={closeModal}
+              className="
+        inline-flex h-11 items-center justify-center rounded-xl px-4
+        text-sm font-medium text-gray-700
+        ring-1 ring-inset ring-gray-200
+        hover:bg-gray-50 active:bg-gray-100 transition
+      "
+            >
+              キャンセル
+            </button>
+
+            <button
+              type="button"
+              onClick={() => {
+                // getCurrentLocation();
+                closeModal();
+              }}
+              className="
+        inline-flex h-11 items-center justify-center rounded-xl px-4
+        text-sm font-semibold text-white
+        bg-gray-900 hover:bg-gray-800
+        shadow-sm active:scale-[0.99] transition
+      "
+            >
+              取得する
+            </button>
+          </div>
+        </Modal>
       </div>
     </div>
   );

--- a/src/app/admin/_components/ThumbnailHandle.tsx
+++ b/src/app/admin/_components/ThumbnailHandle.tsx
@@ -56,7 +56,7 @@ export const ThumbnailHandle: React.FC<{
       closeModal();
       toast.success("現在地取得しました!!");
     } catch {
-      toast.error("現在地取得できませんでした!!");
+      console.error("現在地取得できませんでした!!");
     }
   }
 

--- a/src/app/admin/_components/ThumbnailHandle.tsx
+++ b/src/app/admin/_components/ThumbnailHandle.tsx
@@ -4,14 +4,20 @@ import Image from "next/image";
 import { Button } from "@/app/admin/_components/Button";
 import { Modal } from "./Modal";
 import { useImageHandler } from "@/app/admin/_hooks/useImageHandler";
+import { Coordinate } from "../cafe_submission_form/types/coordinate";
 import "../../globals.css";
+import toast from "react-hot-toast";
 
 export const ThumbnailHandle: React.FC<{
   onImageUpload: (imageUrl: string) => void;
   initialImage?: string;
   isSubmitting: boolean;
+  isLoading: boolean;
+  location: Coordinate | undefined;
+  locationError: string | null;
+  getCurrentLocation: () => Promise<Coordinate>;
   setIsSubmitting: (isSubmitting: boolean) => void;
-}> = ({ onImageUpload, initialImage }) => {
+}> = ({ onImageUpload, initialImage, isLoading, locationError, getCurrentLocation }) => {
   const {
     thumbnailImage,
     handleFileChange,
@@ -38,8 +44,19 @@ export const ThumbnailHandle: React.FC<{
     handleAddClick(); // 実際の画像追加処理
   };
 
+
   const openModal = () => setIsOpen(true);
   const closeModal = () => setIsOpen(false);
+
+  const handleConfirmGetLocation = async() => {
+    try {
+      await getCurrentLocation();
+      closeModal();
+      toast.success("現在地取得しました!!");
+    } catch {
+      toast.error("現在地取得できませんでした!!");
+    }
+  }
 
   return (
     <div className="flex flex-col items-center space-y-4">
@@ -109,7 +126,7 @@ export const ThumbnailHandle: React.FC<{
           </Button>
         </div>
         <div className="px-3">
-          <Button type="button" variant="secondary" onClick={openModal}>
+          <Button type="button" variant="secondary" onClick={openModal} disabled={isLoading}>
             現在地取得
           </Button>
         </div>
@@ -141,10 +158,7 @@ export const ThumbnailHandle: React.FC<{
 
             <button
               type="button"
-              onClick={() => {
-                // getCurrentLocation();
-                closeModal();
-              }}
+              onClick={handleConfirmGetLocation}
               className="
         inline-flex h-11 items-center justify-center rounded-xl px-4
         text-sm font-semibold text-white
@@ -152,11 +166,12 @@ export const ThumbnailHandle: React.FC<{
         shadow-sm active:scale-[0.99] transition
       "
             >
-              取得する
+              {isLoading ? "取得中..." : "取得する"}
             </button>
           </div>
         </Modal>
       </div>
+      {locationError && <p className="text-lg font-bold text-red-500">{locationError}</p>}
     </div>
   );
 };

--- a/src/app/admin/_hooks/useCafeFormState.ts
+++ b/src/app/admin/_hooks/useCafeFormState.ts
@@ -2,6 +2,8 @@
 import React, { useState } from "react";
 import { CafeFormStateProps } from "../_types/CafeFormStateProps";
 import { CafeFormStateReturn } from "../_types/CafeFormStateReturn";
+import { useNearbySearchParams } from "../cafe_submission_form/hooks/useNearbySearchParams";
+import { useCurrentLocation } from "../cafe_submission_form/hooks/useCurrentLocation";
 export const UseCafeFormState = (): CafeFormStateReturn => {
   const cafeState: CafeFormStateProps = {
     cafeName: "",
@@ -20,11 +22,13 @@ export const UseCafeFormState = (): CafeFormStateReturn => {
     starRating: 0,
     comment: "",
     locationCoordinates: "",
+    
   };
 
   const [formState, setFormState] = useState<CafeFormStateProps>(cafeState);
   const [isSubmitting, setIsSubmitting] = useState(false);
-
+  const {location} = useCurrentLocation();
+  const nearby = useNearbySearchParams(location);
   const onChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => {
@@ -54,5 +58,6 @@ export const UseCafeFormState = (): CafeFormStateReturn => {
     clearForm,
     isSubmitting,
     setIsSubmitting,
+    nearby,
   };
 };

--- a/src/app/admin/_types/CafeFormStateReturn.ts
+++ b/src/app/admin/_types/CafeFormStateReturn.ts
@@ -1,4 +1,5 @@
 import { CafeFormStateProps } from "./CafeFormStateProps";
+import { useNearbySearchParams } from "../cafe_submission_form/hooks/useNearbySearchParams";
 
 export type CafeFormStateReturn = {
   formState: CafeFormStateProps;
@@ -8,4 +9,5 @@ export type CafeFormStateReturn = {
   onSubmit?: (e: React.FormEvent) => void;
   isSubmitting: boolean;
   setIsSubmitting: React.Dispatch<React.SetStateAction<boolean>>;
+  nearby: ReturnType<typeof useNearbySearchParams>; // 関数の戻り値型を取得
 }

--- a/src/app/admin/cafe_submission_form/_components/CandidateDropdown.tsx
+++ b/src/app/admin/cafe_submission_form/_components/CandidateDropdown.tsx
@@ -1,0 +1,49 @@
+// 検索結果（候補）を見せて選ばせるUIコンポーネント
+// 状態は、CafePostFormで持たせる(CafePostFormで使うので)
+
+import { PlaceCandidate } from "../types/placeCandidate";
+export const CandidateDropdown = ({
+  open,
+  loading,
+  candidates,
+  onSelect,
+}: {
+  open: boolean;
+  loading: boolean;
+  candidates: PlaceCandidate[];
+  onSelect: (c: PlaceCandidate) => void;
+}) => {
+  if (!open) return null;
+
+  return (
+    <div className="mt-2 rounded-3xl border bg-white shadow">
+      {loading ? (
+        <div className="p-4 text-sm text-black">
+          ☕️ コーヒーを淹れています... お待ちください
+        </div>
+      ): candidates.length === 0 ? (
+        <div className="p-4 text-sm text-gray-500">
+          候補がありません
+        </div>
+      ):(
+        <ul className="max-h-72 overflow-auto">
+          {candidates.map((c) => (
+            <li
+            className="cursor-pointer px-4 py-3 hover:bg-gray-50"
+            key={c.placeId}
+            onMouseDown={(e)=> {
+              e.preventDefault();
+              onSelect(c);
+            }}
+            >
+            <div className="text-sm font-semibold">{c.cafeName}</div>
+            <div className="text-xs text-gray-500">{c.storeAddress}</div>
+            </li>
+          ))}
+        </ul>
+      )
+    
+    }
+    </div>
+  );
+};

--- a/src/app/admin/cafe_submission_form/_components/NearbySearchConditionPanel.tsx
+++ b/src/app/admin/cafe_submission_form/_components/NearbySearchConditionPanel.tsx
@@ -1,0 +1,108 @@
+import { useNearbySearchParams } from "../hooks/useNearbySearchParams";
+// useNearbySearchParams の「戻り値の型」を ReturnType で取得し、型定義を二重管理しない。
+// NearbySearchConditionPanel は条件UI専用コンポーネントなので、
+// Pick で必要なキーだけに絞って「依存範囲」を最小化する（勝手な依存追加を防ぐ）。
+// その結果、フック側の戻り値が拡張/変更されても影響が局所化され、型エラーで気づける。
+type Nearby = ReturnType<typeof useNearbySearchParams>;
+
+type NearbySearchConditionModel = {
+  nearby: Pick<
+    Nearby,
+    | "params"
+    | "radius"
+    | "setRadius"
+    | "rankPreference"
+    | "setRankPreference"
+    | "maxResultCount"
+    | "setMaxResultCount"
+    | "setLanguageCode"
+    | "includedTypes"
+    | "setIncludedTypes"
+  >;
+};
+
+export const NearbySearchConditionPanel = ({
+  nearby,
+}: NearbySearchConditionModel) => {
+
+  const {
+    params,
+    radius,
+    rankPreference,
+    maxResultCount,
+    includedTypes,
+    setRadius,
+    setRankPreference,
+    setMaxResultCount,
+    setIncludedTypes,
+  } = nearby;
+
+  return (
+    <div className="w-[700px] sm:w-full rounded-3xl border bg-white p-5 mb-6">
+      <div className="font-bold mb-4">周辺検索の条件</div>
+
+      {/* 1) radius */}
+      <div className="mb-5">
+        <label className="block text-sm mb-2">検索半径: {radius}m</label>
+        <input
+          className="w-full"
+          type="range"
+          min={100}
+          max={2000}
+          step={50}
+          value={radius}
+          onChange={(e) => setRadius(Number(e.target.value))}
+        />
+        <div className="text-xs text-gray-500 mt-1">
+          狭いほど候補が絞られ、広いほど候補が増えます
+        </div>
+      </div>
+
+      {/* 2) rankPreference */}
+      <div className="mb-5">
+        <label className="block text-sm mb-2">並び順</label>
+        <select
+          className="w-full rounded-2xl border p-3"
+          value={rankPreference}
+          onChange={(e) => setRankPreference(e.target.value as any)}
+        >
+          <option value="DISTANCE">距離が近い順</option>
+          <option value="POPULARITY">人気順</option>
+        </select>
+      </div>
+
+      {/* 3) maxResultCount */}
+      <div className="mb-5">
+        <label className="block text-sm mb-2">候補件数</label>
+        <select
+          className="w-full rounded-2xl border p-3"
+          value={maxResultCount ?? 20}
+          onChange={(e) => setMaxResultCount(Number(e.target.value))}
+        >
+          <option value={5}>5件</option>
+          <option value={10}>10件</option>
+          <option value={20}>20件</option>
+        </select>
+      </div>
+
+      {/* 5) includedTypes */}
+      <div className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          checked={(includedTypes ?? []).includes("cafe")}
+          onChange={(e) =>
+            setIncludedTypes(e.target.checked ? ["cafe"] : undefined)
+          }
+        />
+        <span className="text-sm">カフェに絞る</span>
+      </div>
+
+      {/* paramsが無い時の注意表示（現在地未取得） */}
+      {!params && (
+        <div className="mt-4 text-xs text-red-500">
+          現在地が取得できていないため、周辺検索は実行できません
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/app/admin/cafe_submission_form/_components/NearbySearchConditionPanel.tsx
+++ b/src/app/admin/cafe_submission_form/_components/NearbySearchConditionPanel.tsx
@@ -48,7 +48,7 @@ export const NearbySearchConditionPanel = ({
           className="w-full"
           type="range"
           min={100}
-          max={2000}
+          max={500}
           step={50}
           value={radius}
           onChange={(e) => setRadius(Number(e.target.value))}
@@ -76,7 +76,7 @@ export const NearbySearchConditionPanel = ({
         <label className="block text-sm mb-2">候補件数</label>
         <select
           className="w-full rounded-2xl border p-3"
-          value={maxResultCount ?? 20}
+          value={maxResultCount ?? 50}
           onChange={(e) => setMaxResultCount(Number(e.target.value))}
         >
           <option value={5}>5件</option>

--- a/src/app/admin/cafe_submission_form/_utils/fetchGoogleNearbySearch.ts
+++ b/src/app/admin/cafe_submission_form/_utils/fetchGoogleNearbySearch.ts
@@ -1,0 +1,41 @@
+import { NearbySearchParams } from "../types/nearbySearchParams";
+import { GoogleNearbySearchResponse } from "../types/googleNearbySearchResponse";
+
+
+// fetch（外部呼び出し）
+const FIELD_MASK = [
+  "places.id",
+  "places.displayName",
+  "places.formattedAddress",
+  "places.location",
+  "places.primaryType",
+  "places.types",
+].join(",");
+
+// Google Places Nearby Search (New) を呼び出して、生レスポンス(JSON)を返す（HTTPエラーは例外）
+export const fetchNearbySearch = async (
+  params: NearbySearchParams,
+  apiKey: string,
+) => {
+  const res = await fetch(
+    "https://places.googleapis.com/v1/places:searchNearby",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Goog-Api-Key": apiKey,
+        "X-Goog-FieldMask": FIELD_MASK,
+      },
+      body: JSON.stringify(params),
+      cache: "no-cache",
+    },
+  );
+
+  const json = (await res.json()) as GoogleNearbySearchResponse;
+
+  if (!res.ok) {
+    throw new Error(json.error?.message ?? "Places API error");
+  }
+
+  return json;
+};

--- a/src/app/admin/cafe_submission_form/_utils/fetchNearbyCandidates.ts
+++ b/src/app/admin/cafe_submission_form/_utils/fetchNearbyCandidates.ts
@@ -1,0 +1,17 @@
+import { NearbySearchParams } from "../types/nearbySearchParams";
+import { PlaceCandidate } from "../types/placeCandidate";
+import api from "@/_utils/api";
+
+type NearbySearchResult = { candidates: PlaceCandidate[] };
+
+// クライアントから自アプリのAPI（/api/admin/cafe_submission_form/nearby-search）へPOSTして、
+// サーバー側(route.ts)がGoogle Places Nearby Searchを代理実行した結果（PlaceCandidate[]）を受け取るための関数。
+// ※Google APIキーをクライアントに露出させない目的
+
+export const fetchNearbyCandidates = async (params: NearbySearchParams): Promise<PlaceCandidate[]> => {
+  const res = await api.post<NearbySearchParams, NearbySearchResult>(
+    "/api/admin/cafe_submission_form/nearby-search",
+    params
+  );
+  return res.candidates;
+};

--- a/src/app/admin/cafe_submission_form/_utils/fetchNearbyCandidates.ts
+++ b/src/app/admin/cafe_submission_form/_utils/fetchNearbyCandidates.ts
@@ -10,7 +10,7 @@ type NearbySearchResult = { candidates: PlaceCandidate[] };
 
 export const fetchNearbyCandidates = async (params: NearbySearchParams): Promise<PlaceCandidate[]> => {
   const res = await api.post<NearbySearchParams, NearbySearchResult>(
-    "/api/admin/cafe_submission_form/nearby-search",
+    "/api/admin/cafe_submission_form/nearby_search",
     params
   );
   return res.candidates;

--- a/src/app/admin/cafe_submission_form/_utils/googleNearbySearch.mapper.ts
+++ b/src/app/admin/cafe_submission_form/_utils/googleNearbySearch.mapper.ts
@@ -2,6 +2,11 @@ import { PlaceCandidate } from "../types/placeCandidate";
 import { GoogleNearbySearchResponse } from "../types/googleNearbySearchResponse";
 // 周辺情報を投稿フォーム形式で一覧表示するための関数
 
+// 文頭の"日本、"を削除する処理
+const normalizeJapanAddress = (address: string) => {
+  return address.replace(/^日本[、,\s]*/u, "").trim();
+}
+
 // フロント側で扱いやすい候補一覧に整形して、使えない候補を排除
 export const mapGoogleNearbySearchToPlaceCandidate = (
   json: GoogleNearbySearchResponse,
@@ -10,10 +15,10 @@ export const mapGoogleNearbySearchToPlaceCandidate = (
     .map((place) => ({
       placeId: place.id,
       cafeName: place.displayName?.text ?? "",
-      storeAddress: place.formattedAddress ?? "",
+      storeAddress: normalizeJapanAddress(place.formattedAddress ?? ""),
       locationCoordinates: {
-        lat: place.location?.latitude ?? 0,
-        lng: place.location?.longitude ?? 0,
+        latitude: place.location?.latitude ?? 0,
+        longitude: place.location?.longitude ?? 0,
       },
       primaryType: place.primaryType,
       types: place.types ?? [],

--- a/src/app/admin/cafe_submission_form/_utils/googleNearbySearch.mapper.ts
+++ b/src/app/admin/cafe_submission_form/_utils/googleNearbySearch.mapper.ts
@@ -1,0 +1,22 @@
+import { PlaceCandidate } from "../types/placeCandidate";
+import { GoogleNearbySearchResponse } from "../types/googleNearbySearchResponse";
+// 周辺情報を投稿フォーム形式で一覧表示するための関数
+
+// フロント側で扱いやすい候補一覧に整形して、使えない候補を排除
+export const mapGoogleNearbySearchToPlaceCandidate = (
+  json: GoogleNearbySearchResponse,
+): PlaceCandidate[] => {
+  return (json.places ?? [])
+    .map((place) => ({
+      placeId: place.id,
+      cafeName: place.displayName?.text ?? "",
+      storeAddress: place.formattedAddress ?? "",
+      locationCoordinates: {
+        lat: place.location?.latitude ?? 0,
+        lng: place.location?.longitude ?? 0,
+      },
+      primaryType: place.primaryType,
+      types: place.types ?? [],
+    }))
+    .filter((c) => c.placeId && c.cafeName && c.storeAddress);
+};

--- a/src/app/admin/cafe_submission_form/hooks/useCurrentLocation.ts
+++ b/src/app/admin/cafe_submission_form/hooks/useCurrentLocation.ts
@@ -37,7 +37,7 @@ export const useCurrentLocation = () => {
     }
   }, []);
 
-  // プライバシー配慮で、位置情報をリセット(error/loading も含めて初期化)
+  // 位置情報をキャンセルした場合、リセット(error/loading も含めて初期化)
   const reset = useCallback(() => {
     setLocation(undefined);
     setError(null);

--- a/src/app/admin/cafe_submission_form/hooks/useCurrentLocation.ts
+++ b/src/app/admin/cafe_submission_form/hooks/useCurrentLocation.ts
@@ -29,9 +29,16 @@ export const useCurrentLocation = () => {
     setError(null);
     try {
       const pos = await getPosition({ timeout: 10000, maximumAge: 60000 });
-      setLocation({ lat: pos.coords.latitude, lng: pos.coords.longitude });
+      const loc = { lat: pos.coords.latitude, lng: pos.coords.longitude };
+      setLocation(loc);
+      console.log("現在地取得できました:", loc);
+      return loc;
     } catch (err: unknown) {
-      setError(toErrorMessage(err));
+      const errorMessage = err instanceof Error ? err.message : "位置情報の取得に失敗しました";
+      const msg = toErrorMessage(errorMessage);
+      setError(msg)
+      console.log(msg);
+      throw new Error(msg);
     } finally {
       setIsLoading(false);
     }

--- a/src/app/admin/cafe_submission_form/hooks/useCurrentLocation.ts
+++ b/src/app/admin/cafe_submission_form/hooks/useCurrentLocation.ts
@@ -29,7 +29,7 @@ export const useCurrentLocation = () => {
     setError(null);
     try {
       const pos = await getPosition({ timeout: 10000, maximumAge: 60000 });
-      const loc = { lat: pos.coords.latitude, lng: pos.coords.longitude };
+      const loc = { latitude: pos.coords.latitude, longitude: pos.coords.longitude };
       setLocation(loc);
       console.log("現在地取得できました:", loc);
       return loc;

--- a/src/app/admin/cafe_submission_form/hooks/useCurrentLocation.ts
+++ b/src/app/admin/cafe_submission_form/hooks/useCurrentLocation.ts
@@ -1,0 +1,48 @@
+import { useState, useCallback } from "react";
+import { Coordinate } from "../types/coordinate";
+// 現在地のみを取得するカスタムフック
+
+// 現在地を1回取得（Promise化して await できるようにしてる）
+const getPosition = (option?: PositionOptions) =>
+  new Promise<GeolocationPosition>((resolve, reject) => {
+    if (!navigator.geolocation) {
+      reject(new Error("この環境では位置情報を利用できません"));
+      return;
+    }
+    // 1回取得して、成功ならresolve(pos) 失敗ならreject(err)が呼ばれる。
+    navigator.geolocation.getCurrentPosition(resolve, reject, option);
+  });
+// エラーメッセージ(unknownで型を安全にstring変換)
+const toErrorMessage = (err: unknown) => {
+  if (err instanceof Error) return err.message;
+  return "位置情報の取得に失敗しました";
+};
+
+// location / error / isLoading の状態管理＋取得関数を提供
+export const useCurrentLocation = () => {
+  const [location, setLocation] = useState<Coordinate | undefined>(undefined);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  const getCurrentLocation = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const pos = await getPosition({ timeout: 10000, maximumAge: 60000 });
+      setLocation({ lat: pos.coords.latitude, lng: pos.coords.longitude });
+    } catch (err: unknown) {
+      setError(toErrorMessage(err));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  // プライバシー配慮で、位置情報をリセット(error/loading も含めて初期化)
+  const reset = useCallback(() => {
+    setLocation(undefined);
+    setError(null);
+    setIsLoading(false);
+  }, []);
+
+  return { location, error, isLoading, getCurrentLocation, reset };
+};

--- a/src/app/admin/cafe_submission_form/hooks/useNearbySearchParams.ts
+++ b/src/app/admin/cafe_submission_form/hooks/useNearbySearchParams.ts
@@ -1,0 +1,52 @@
+import { useState, useMemo } from "react";
+import { Coordinate } from "../types/coordinate";
+import { NearbySearchParams } from "../types/nearbySearchParams";
+
+// Nearby Search (Places API) のリクエストボディ(params)を作るためのフック。
+// UIで変更できる検索条件（radius など）を状態管理し、現在地(location)がある時だけ params を組み立てる。
+
+//検索フォームの状態管理のフック(検索条件を作る・持つ)
+export const useNearbySearchParams = (location: Coordinate | undefined) => {
+  // 検索フォーム上でユーザーが自由に変更できる“検索条件”を、Reactの状態として持つため
+  const [radius, setRadius] = useState(500);
+  const [languageCode, setLanguageCode] = useState<string | undefined>("ja");
+  const [rankPreference, setRankPreference] =
+    useState<NearbySearchParams["rankPreference"]>("DISTANCE");
+  const [maxResultCount, setMaxResultCount] = useState<number | undefined>(20);
+  const [includedTypes, setIncludedTypes] = useState<string[] | undefined>(
+    undefined,
+  );
+  
+  const params = useMemo<NearbySearchParams | undefined>(() => {
+    if (!location) return undefined;
+    
+    return {
+      locationRestriction: { circle: { center: location, radius } },
+      languageCode,
+      rankPreference,
+      maxResultCount,
+      includedTypes,
+    };
+  }, [
+    location,
+    radius,
+    languageCode,
+    rankPreference,
+    maxResultCount,
+    includedTypes,
+  ]);
+
+  return {
+    params,
+    radius,
+    languageCode,
+    rankPreference,
+    maxResultCount,
+    includedTypes,
+    setRadius,
+    setLanguageCode,
+    setRankPreference,
+    setMaxResultCount,
+    setIncludedTypes,
+  };
+};

--- a/src/app/admin/cafe_submission_form/page.tsx
+++ b/src/app/admin/cafe_submission_form/page.tsx
@@ -28,7 +28,7 @@ const CafeSubmissionForm: React.FC = () => {
     }));
   };
 
-  const { location, isLoading, error, getCurrentLocation } =
+  const { location, isLoading, error, getCurrentLocation, reset } =
     useCurrentLocation();
   return (
     <div>
@@ -45,6 +45,7 @@ const CafeSubmissionForm: React.FC = () => {
           isLoading={isLoading}
           location={location}
           locationError={error}
+          reset={reset}
           getCurrentLocation={getCurrentLocation}
         />
         <CafePostForm

--- a/src/app/admin/cafe_submission_form/page.tsx
+++ b/src/app/admin/cafe_submission_form/page.tsx
@@ -5,6 +5,7 @@ import { CafePostForm } from "../_components/CafePostForm";
 import { ThumbnailHandle } from "../_components/ThumbnailHandle";
 import { UseCafeFormState } from "../_hooks/useCafeFormState";
 import { useCurrentLocation } from "./hooks/useCurrentLocation";
+import { useNearbySearchParams } from "./hooks/useNearbySearchParams";
 import "../../globals.css";
 
 const CafeSubmissionForm: React.FC = () => {
@@ -30,6 +31,8 @@ const CafeSubmissionForm: React.FC = () => {
 
   const { location, isLoading, error, getCurrentLocation, reset } =
     useCurrentLocation();
+
+  const nearby = useNearbySearchParams(location);
   return (
     <div>
       <HeaderAdminBase href="/admin/home" />
@@ -55,6 +58,7 @@ const CafeSubmissionForm: React.FC = () => {
           clearForm={clearForm}
           isSubmitting={isSubmitting}
           setIsSubmitting={setIsSubmitting}
+          nearby={nearby}
         />
       </div>
     </div>

--- a/src/app/admin/cafe_submission_form/page.tsx
+++ b/src/app/admin/cafe_submission_form/page.tsx
@@ -4,6 +4,7 @@ import { HeaderAdminBase } from "../_components/HeaderAdminBase";
 import { CafePostForm } from "../_components/CafePostForm";
 import { ThumbnailHandle } from "../_components/ThumbnailHandle";
 import { UseCafeFormState } from "../_hooks/useCafeFormState";
+import { useCurrentLocation } from "./hooks/useCurrentLocation";
 import "../../globals.css";
 
 const CafeSubmissionForm: React.FC = () => {
@@ -18,7 +19,7 @@ const CafeSubmissionForm: React.FC = () => {
   };
 
   const handleChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) => {
     const { name, value } = e.target;
     setFormState((prev: typeof formState) => ({
@@ -26,18 +27,25 @@ const CafeSubmissionForm: React.FC = () => {
       [name]: value,
     }));
   };
-  
-  console.log(formState);
+
+  const { location, isLoading, error, getCurrentLocation } =
+    useCurrentLocation();
   return (
     <div>
       <HeaderAdminBase href="/admin/home" />
-      <div className="bg-tan-300">      
-      <h1 className="flex justify-center font-bold text-3xl pt-[100px]">カフェ投稿</h1>
+      <div className="bg-tan-300">
+        <h1 className="flex justify-center font-bold text-3xl pt-[100px]">
+          カフェ投稿
+        </h1>
         <ThumbnailHandle
           onImageUpload={handleImageUpload}
           initialImage={formState.thumbnailImage}
           isSubmitting={isSubmitting}
           setIsSubmitting={setIsSubmitting}
+          isLoading={isLoading}
+          location={location}
+          locationError={error}
+          getCurrentLocation={getCurrentLocation}
         />
         <CafePostForm
           formState={formState}

--- a/src/app/admin/cafe_submission_form/types/cafeLocationFormState.ts
+++ b/src/app/admin/cafe_submission_form/types/cafeLocationFormState.ts
@@ -1,10 +1,9 @@
-import { Coordinate } from "./coordinate"
-import {  Cafe } from "@prisma/client";
+import { Cafe } from "@prisma/client";
+import { Coordinate } from "./coordinate";
+import { CafeFormStateProps } from "../../_types/CafeFormStateProps";
 
-// 現在地とお店の位置情報
-export type CafeLocationFormState = {
-  location?: Coordinate;
-  storeAddress?: Cafe["storeAddress"];
-  cafeName?: Cafe["cafeName"];
-  isLoading: boolean;
-};
+//現在地とお店の位置情報のレスポンスの結果をフォーム(投稿データ)に変換するためのフォームの型
+export type CafeLocationFormState = Pick<
+  CafeFormStateProps,
+  "cafeName" | "storeAddress"
+> & { placeId?: Cafe["placeId"]; locationCoordinates: Coordinate };

--- a/src/app/admin/cafe_submission_form/types/coordinate.ts
+++ b/src/app/admin/cafe_submission_form/types/coordinate.ts
@@ -1,5 +1,5 @@
 
 export type Coordinate = {
-  lat: number;
-  lng: number;
+  latitude: number;
+  longitude: number;
 };

--- a/src/app/admin/cafe_submission_form/types/googleNearbySearchResponse.ts
+++ b/src/app/admin/cafe_submission_form/types/googleNearbySearchResponse.ts
@@ -1,0 +1,12 @@
+// Google APIが返すデータ（生レスポンス）を、サーバ側で扱うための型
+export type GoogleNearbySearchResponse = {
+  places?: Array<{
+    id?: number;
+    displayName?: { text?: string };
+    formattedAddress?: string;
+    location?: { latitude?: number; longitude?: number };
+    primaryType?: string;
+    types?: string[];
+  }>;
+  error?: { message?: string };
+};

--- a/src/app/admin/cafe_submission_form/types/nearbySearchParams.ts
+++ b/src/app/admin/cafe_submission_form/types/nearbySearchParams.ts
@@ -1,0 +1,18 @@
+import { Coordinate } from "./coordinate";
+
+// 要件: 現在地の周辺候補をだす。
+// Places API Nearby Search (New) の リクエストボディ（JSON）で渡すパラメータ構造の型定義
+
+export type NearbySearchParams = {
+  locationRestriction: {
+    circle: { 
+      center: Coordinate; // 中心(現在地)
+      radius: number; // 半径(メートル)
+    }; // 中心 + 半径
+  }; // 検索範囲
+  languageCode?: string; // 名称や住所表記の言語指定
+  rankPreference?: "DISTANCE" | "POPULARITY"; // 現在地周辺の候補の条件 距離優先指定 DISTANCE:距離優先 POPULARITY: 人気優先
+  maxResultCount?: number; // 候補一覧の件数
+  includedTypes?: string[]; // 含めたいカテゴリだけを絞る
+  excludedTypes?: string[]; // 除外したいカテゴリを外す
+}

--- a/src/app/admin/cafe_submission_form/types/placeCandidate.ts
+++ b/src/app/admin/cafe_submission_form/types/placeCandidate.ts
@@ -1,0 +1,11 @@
+import { Cafe } from "@prisma/client";
+import { Coordinate } from "./coordinate";
+// 現在地とお店の位置情報のレスポンス型
+export type PlaceCandidate = {
+  placeId?: Cafe["placeId"];
+  cafeName: Cafe["cafeName"];
+  storeAddress: Cafe["storeAddress"];
+  locationCoordinates: Coordinate;
+  primaryType?: Cafe["primaryType"];
+  types: Cafe[];
+};

--- a/src/app/admin/cafe_submission_form/types/placeCandidate.ts
+++ b/src/app/admin/cafe_submission_form/types/placeCandidate.ts
@@ -7,5 +7,5 @@ export type PlaceCandidate = {
   storeAddress: Cafe["storeAddress"];
   locationCoordinates: Coordinate;
   primaryType?: Cafe["primaryType"];
-  types: Cafe[];
+  types: Cafe["types"];
 };

--- a/src/app/admin/cafe_submission_form/types/placeCandidate.ts
+++ b/src/app/admin/cafe_submission_form/types/placeCandidate.ts
@@ -1,7 +1,7 @@
 import { Coordinate } from "./coordinate";
 // 現在地とお店の位置情報のレスポンス型
 export type PlaceCandidate = {
-  placeId?: string;
+  placeId?: number;
   cafeName: string;
   storeAddress: string;
   locationCoordinates: Coordinate;

--- a/src/app/admin/cafe_submission_form/types/placeCandidate.ts
+++ b/src/app/admin/cafe_submission_form/types/placeCandidate.ts
@@ -1,11 +1,10 @@
-import { Cafe } from "@prisma/client";
 import { Coordinate } from "./coordinate";
 // 現在地とお店の位置情報のレスポンス型
 export type PlaceCandidate = {
-  placeId?: Cafe["placeId"];
-  cafeName: Cafe["cafeName"];
-  storeAddress: Cafe["storeAddress"];
+  placeId?: string;
+  cafeName: string;
+  storeAddress: string;
   locationCoordinates: Coordinate;
-  primaryType?: Cafe["primaryType"];
-  types: Cafe["types"];
+  primaryType?: string;
+  types: string[];
 };

--- a/src/app/admin/user_account/page.tsx
+++ b/src/app/admin/user_account/page.tsx
@@ -9,6 +9,7 @@ import { FooterDefault } from "@/app/_components/Footer/FooterDefault";
 import toast, { Toaster } from "react-hot-toast";
 import "./../../globals.css";
 
+
 const UserAccount: React.FC = () => {
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   const [formState, setFormState] = useState<UserAccountFormProps>({
@@ -35,7 +36,9 @@ const UserAccount: React.FC = () => {
 
     try {
       const data = await api.post("/api/admin/user_account", formState);
-      toast.success(data.message || "ユーザー登録が完了しました！");
+      // data がオブジェクトで、message というプロパティを持っていたら、それを文字列にして message に入れる。なければ undefined にする
+      const message = typeof data === "object" && data !== null && "message" in data ? String((data as any).message): undefined;
+      toast.success(message || "ユーザー登録が完了しました！");
     } catch (error) {
       console.error("ユーザー登録エラー:", error);
       toast.error(error instanceof Error ? error.message : "ユーザー登録に失敗しました。もう一度お試しください。");
@@ -60,7 +63,8 @@ const UserAccount: React.FC = () => {
 
     try {
       const data = await api.put("/api/admin/user_account", formState);
-      toast.success(data.message || "ユーザー情報を更新しました");
+            const message = typeof data === "object" && data !== null && "message" in data ? String((data as any).message): undefined;
+      toast.success(message || "ユーザー情報を更新しました");
     } catch (error) {
       console.error("更新エラー:", error);
       toast.error(error instanceof Error ? error.message : "更新に失敗しました");

--- a/src/app/api/admin/cafe_submission_form/nearby_search/route.ts
+++ b/src/app/api/admin/cafe_submission_form/nearby_search/route.ts
@@ -1,26 +1,15 @@
 import { NextResponse } from "next/server";
 import { NearbySearchParams } from "@/app/admin/cafe_submission_form/types/nearbySearchParams";
-import { PlaceCandidate } from "@/app/admin/cafe_submission_form/types/placeCandidate";
+import { mapGoogleNearbySearchToPlaceCandidate } from "@/app/admin/cafe_submission_form/_utils/googleNearbySearch.mapper";
+import { fetchNearbySearch } from "@/app/admin/cafe_submission_form/_utils/fetchGoogleNearbySearch";
 
-// APIキーが漏れるの防ぐため、APIを叩く処理をサーバーサイド側で処理
-// GoogleNearbySearchResponse でGoogleからのレスポンス処理
+// Google APIキーをクライアントに露出させないため、Places API 呼び出しはサーバー側(route.ts)で代理実行する
 
-type GoogleNearbySearchResponse = {
-  places?: Array<{
-    id?: number;
-    displayName?: { text?: string };
-    formattedAddress?: string;
-    location?: { latitude?: number; longitude?: number };
-    primaryType?: string;
-    types?: string[];
-  }>;
-  error?: { message: string };
-};
 
 // POSTメソッドでリクエスト処理とレスポンス
 // Nearby Searchは、POSTのみサポートしている
 export const POST = async (request: Request) => {
-  const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAP_API_KEY;
+  const apiKey = process.env.GOOGLE_MAP_API_KEY;
   if (!apiKey) {
     return NextResponse.json(
       { message: "APIキーがありません" },
@@ -28,54 +17,14 @@ export const POST = async (request: Request) => {
     );
   }
 
-// フロントから受け取ったリクエストボディに NearbySearchParams の型を付けて扱う
-// TODO バリデーションは 運用時の安全で、Zod などを使うと一気に楽かも
   const params = (await request.json()) as NearbySearchParams;
 
-// NearbySearchParamsでは、1つ以上のデータ型を指定するフィールドマスクが必須
-// レスポンスで返すフィールドのリストを指定
-  const res = await fetch(
-    "https://places.googleapis.com/v1/places:searchNearby",
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Goog-Api-Key": apiKey,
-        "X-Goog-FieldMask": [
-          "places.id",
-          "places.displayName",
-          "places.formattedAddress",
-          "places.location",
-          "places.primaryType",
-          "places.types",
-        ].join(","),
-      },
-      body: JSON.stringify(params),
-      cache: "no-store",
-    },
-  );
-
-  const json = (await res.json()) as GoogleNearbySearchResponse;
-
-  if (!res.ok) {
-    return NextResponse.json(
-      { message: json.error?.message ?? "Places API error" },
-      { status: res.status },
-    );
+  try {
+    const json = await fetchNearbySearch(params, apiKey);
+    const candidates = mapGoogleNearbySearchToPlaceCandidate(json);
+    return NextResponse.json({ candidates });
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : "検索に失敗しました";
+    return NextResponse.json({ message }, { status: 400 });
   }
-
-  // フロント側で扱いやすい候補一覧に整形して、使えない候補を排除
-  const candidates: PlaceCandidate[] = (json.places ?? []).map((place) => ({
-    placeId: place.id,
-    cafeName: place.displayName?.text ?? "",
-    storeAddress: place.formattedAddress ?? "",
-    locationCoordinates: {
-      lat: place.location?.latitude ?? 0,
-      lng: place.location?.longitude ?? 0,
-    },
-    primaryType: place.primaryType,
-    types: place.types ?? [],
-  })).filter((c) => c.placeId && c.cafeName && c.storeAddress);
-
-  return NextResponse.json({candidates})
 };

--- a/src/app/api/admin/cafe_submission_form/nearby_search/route.ts
+++ b/src/app/api/admin/cafe_submission_form/nearby_search/route.ts
@@ -5,11 +5,11 @@ import { fetchNearbySearch } from "@/app/admin/cafe_submission_form/_utils/fetch
 
 // Google APIキーをクライアントに露出させないため、Places API 呼び出しはサーバー側(route.ts)で代理実行する
 
-
 // POSTメソッドでリクエスト処理とレスポンス
 // Nearby Searchは、POSTのみサポートしている
+
 export const POST = async (request: Request) => {
-  const apiKey = process.env.GOOGLE_MAP_API_KEY;
+  const apiKey = process.env.GOOGLE_PLACES_API_KEY;
   if (!apiKey) {
     return NextResponse.json(
       { message: "APIキーがありません" },
@@ -21,7 +21,9 @@ export const POST = async (request: Request) => {
 
   try {
     const json = await fetchNearbySearch(params, apiKey);
+
     const candidates = mapGoogleNearbySearchToPlaceCandidate(json);
+
     return NextResponse.json({ candidates });
   } catch (e: unknown) {
     const message = e instanceof Error ? e.message : "検索に失敗しました";

--- a/src/app/api/admin/cafe_submission_form/nearby_search/route.ts
+++ b/src/app/api/admin/cafe_submission_form/nearby_search/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from "next/server";
+import { NearbySearchParams } from "@/app/admin/cafe_submission_form/types/nearbySearchParams";
+import { PlaceCandidate } from "@/app/admin/cafe_submission_form/types/placeCandidate";
+
+// APIキーが漏れるの防ぐため、APIを叩く処理をサーバーサイド側で処理
+// GoogleNearbySearchResponse でGoogleからのレスポンス処理
+
+type GoogleNearbySearchResponse = {
+  places?: Array<{
+    id?: number;
+    displayName?: { text?: string };
+    formattedAddress?: string;
+    location?: { latitude?: number; longitude?: number };
+    primaryType?: string;
+    types?: string[];
+  }>;
+  error?: { message: string };
+};
+
+// POSTメソッドでリクエスト処理とレスポンス
+// Nearby Searchは、POSTのみサポートしている
+export const POST = async (request: Request) => {
+  const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAP_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { message: "APIキーがありません" },
+      { status: 500 },
+    );
+  }
+
+// フロントから受け取ったリクエストボディに NearbySearchParams の型を付けて扱う
+// TODO バリデーションは 運用時の安全で、Zod などを使うと一気に楽かも
+  const params = (await request.json()) as NearbySearchParams;
+
+// NearbySearchParamsでは、1つ以上のデータ型を指定するフィールドマスクが必須
+// レスポンスで返すフィールドのリストを指定
+  const res = await fetch(
+    "https://places.googleapis.com/v1/places:searchNearby",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Goog-Api-Key": apiKey,
+        "X-Goog-FieldMask": [
+          "places.id",
+          "places.displayName",
+          "places.formattedAddress",
+          "places.location",
+          "places.primaryType",
+          "places.types",
+        ].join(","),
+      },
+      body: JSON.stringify(params),
+      cache: "no-store",
+    },
+  );
+
+  const json = (await res.json()) as GoogleNearbySearchResponse;
+
+  if (!res.ok) {
+    return NextResponse.json(
+      { message: json.error?.message ?? "Places API error" },
+      { status: res.status },
+    );
+  }
+
+  // フロント側で扱いやすい候補一覧に整形して、使えない候補を排除
+  const candidates: PlaceCandidate[] = (json.places ?? []).map((place) => ({
+    placeId: place.id,
+    cafeName: place.displayName?.text ?? "",
+    storeAddress: place.formattedAddress ?? "",
+    locationCoordinates: {
+      lat: place.location?.latitude ?? 0,
+      lng: place.location?.longitude ?? 0,
+    },
+    primaryType: place.primaryType,
+    types: place.types ?? [],
+  })).filter((c) => c.placeId && c.cafeName && c.storeAddress);
+
+  return NextResponse.json({candidates})
+};

--- a/src/app/api/admin/cafe_submission_form/route.ts
+++ b/src/app/api/admin/cafe_submission_form/route.ts
@@ -21,6 +21,9 @@ export const GET = async (request: NextRequest) => {
           select: {
             id: true,
             cafeName: true,
+            placeId: true,
+            primaryType: true,
+            types: true,
             thumbnailImage: true,
             openingTime: true,
             closingHours: true,
@@ -80,6 +83,9 @@ export const POST = async (request: NextRequest) => {
       cafeName,
       area,
       storeAddress,
+      placeId,
+      primaryType,
+      types,
       businessHours,
       thumbnailImage,
       closingDays,
@@ -98,6 +104,9 @@ export const POST = async (request: NextRequest) => {
     if (
       !cafeName ||
       !storeAddress ||
+      !placeId||
+      !primaryType ||
+      !types ||
       starRating === null ||
       wifiAvailable === null ||
       powerOutlets === null ||
@@ -121,6 +130,9 @@ export const POST = async (request: NextRequest) => {
         cafeName,
         area,
         storeAddress,
+        placeId,
+        primaryType,
+        types,
         openingTime,
         closingHours,
         thumbnailImage,


### PR DESCRIPTION
## 【要件】
- 店舗住所（storeAddress）入力欄をフォーカスしたら候補取得を開始する
- 近い順に候補（店名＋住所）を表示する（例：最大10件、半径500m）
- ユーザーが候補を選ぶと、店舗住所欄に自動入力される（
- 取得できない／現在地が取れない場合は、エラー表示



https://github.com/ken512/WorkBrew/pull/21/commits/0f72e83f2d4538ff1b33376bafcb744e36fb24db
## **やったこと**
現在地から周辺の店舗情報を取得する機能を追加するため、CafeモデルにplaceId・primaryType・typesを追加。


- placeId
現在地から周辺の情報を一意に識別するためのID

- primaryType
投稿時に、カフェ情報のみを投稿できるようにカフェ情報以外を弾くため
例: primaryType === "cafe”のみ投稿できる仕様にする。

- types
primaryTypeのズレをなくすため。
primaryTypeがv”bakery”でも、typesで”cafe”にすれば、カフェとして扱えるようにするため。
広い検索結果から、カフェっぽいのみを抽出するイメージ。


https://github.com/ken512/WorkBrew/pull/21/commits/e5df6208d7068235032f71b14f506a6af83ec1f2
現在地とお店の位置情報のレスポンスの結果をフォーム(投稿データ)に変換するためのフォームの型を追加

## **やったこと**
周辺情報の候補一覧をフォームに反映させるために、現在地と周辺情報のレスポンス結果をフォームに変換する必要があり、
フォームの型を追加


https://github.com/ken512/WorkBrew/pull/21/commits/08aa631f6f65e8f36480274170a99906107e6cc3
## **やったこと**
現在地の周辺候補一覧を表示させるために、Places API Nearby Search (New) の リクエストボディ（JSON）で渡すパラメータ構造の型定義を追加

https://github.com/ken512/WorkBrew/pull/21/commits/8a1daa2f7d31f668f7c9e8527628a3be4e0ea30a
## **やったこと**
アプリの中心（Cafe＝投稿/保存データ）が、外部サービス（Places候補）**に引っ張られてしまうの問題を解消すべく、依存を断ち切る形で修正。
将来、変更したときに他の機能にも影響ができないように、それぞれの機能の役割を独立させるため。

https://github.com/ken512/WorkBrew/pull/21/commits/909a37c804b8d86ff0c824994301b014044dfdf4
## **やったこと**
現在地取得用のカスタムフックを実装
今回現在地取得のが目的なので、エラーハンドリングなど結果をUIで表示させる必要があるため、
Promiseと一緒にtry / catch / finallyでまとめた。

https://github.com/ken512/WorkBrew/pull/21/commits/b766b2e3427d59035254d3df5c4a8c4c376aa965
## **やったこと**
Nearby Search (Places API) のリクエストボディ(params)を作るためのフックを実装。
UIで変更できる検索条件（radius など）を状態管理し、現在地(location)がある時だけ params を組み立て。
今回はparamsを作るためのフックで、API叩くのは別のフックで定義する。

https://github.com/ken512/WorkBrew/pull/21/changes/4b6c0734b04f59669a1fadb426a507633af00ad3
## **やったこと**
APIキーが漏れるの防ぐため、APIを叩く処理をサーバーサイド側で処理
GoogleNearbySearchResponse でGoogleからのレスポンス処理

https://github.com/ken512/WorkBrew/pull/21/commits/146b9d6db006726f465bcba6b8f4c92c00fa51a7
## **やったこと**
Nearby Searchをfetch/mapper/routeに分離
- Nearby SearchをPlaces Nearby Searchを外部呼び出しで生レスポンス(JSON)を返す 
- Googleのレスポンスを、フロントで扱えるようにPlaceCandidate[]に変換 
- GoogleAPIキーをクライアントの露出させらないために、Places API呼び出しはサーバー側で実行

https://github.com/ken512/WorkBrew/pull/21/changes/dce41d86f45739a09988138d32bf39d0936794b4
## **やったこと**
現在地取得ボタンUIとモーダルによる任意確認UIの追加

https://github.com/ken512/WorkBrew/pull/21/changes/7f0924264a577e4d96a431179b2edcf11e6a54be
## **やったこと**
- 現在地取得カスタムフックの連携
   useCurrentLocation（現在地取得専用カスタムフック）を
  呼び出し側コンポーネント（ThumbnailHandle）から利用するように実装

- フロント画面での現在地取得UI実装
  ユーザー操作で現在地を取得できるフローをフロント側に実装
  
- カスタムフックの設計改善（return対応）
  getCurrentLocation を 位置情報を返す設計（Promise）に修正
   呼び出し側で try / catch による成功・失敗分岐が可能になるよう改善

- 動作確認
   コンソールログを追加して現在地取得が正常に行えることを確認

https://github.com/ken512/WorkBrew/pull/21/changes/a4170c74c33d2d7a69fe4f752a01758bf398c263
**やったこと**
- Places Nearby Searchをサーバー経由で呼ぶfetch関数を追加
- requestに共通でまとめたPOSTメソッドに、Req/Res型を明確化の仕様に修正
- 現在地取得ボタンのUIスタイ変更・クリア処理を追加


https://github.com/ken512/WorkBrew/pull/21/changes/13ee5a7f5fe1669fcecc4bcc17204e2c09e8e5d8
## **やったこと**
① 現在地取得の改善

- useCurrentLocation を Promiseベースに修正
- getCurrentLocation(): Promise<Coordinate> に変更
- 呼び出し側で await できる設計に改善
- reset() を用意し、状態初期化可能に
- モーダルUIで現在地取得を実装

🔹 サーバー側
② Nearby Search API構造の整理（責任分離）

- /api/admin/cafe_submission_form/nearby-search を作成
- Google Places APIを サーバー側で代理実行
- APIキーをクライアントに露出させない設計
- fetchNearbySearch を外部API専用に分離
- mapGoogleNearbySearchToPlaceCandidate で整形
- formattedAddress から "日本、" を除去

## 🔹 クライアント側
③ Nearby検索条件の状態管理

- fetchNearbyCandidates を作成
- 自アプリAPIにPOSTする関数を実装
- <Req, Res>ジェネリクス対応のapi.postに変更
- 型安全な通信設計に改善
- useNearbySearchParams 作成
- locationがある時だけ params を生成
- 親コンポーネントで管理
- ReturnType<typeof useNearbySearchParams> を props型に利用

④ 住所欄フォーカス時の処理

- onFocus で Nearby検索を発火
-  候補を state 管理
- CandidateDropdown 実装
- 住所選択で formState に反映

⑤ UI改善

- 条件パネル表示状態を isConditionPanelOpen に変更
- 候補表示UIをstoreAddress限定に
- ダイアログ型UIで候補表示
- 文頭「日本、」除去処理を追加

https://github.com/ken512/WorkBrew/pull/21/changes/b0b67bb14d9d70380403d2269675c515feaae045
## **やったこと**

- CafeFormStateReturn に合わせて UseCafeFormState で nearby を生成し返却
- useNearbySearchParams(location) を追加
- 戻り値に nearby を含めて型と実装を一致
- api.post/put の戻り値が unknown 扱いになるケースに対応
- レスポンス data から message を 存在チェックして安全に取り出す処理を追加
- toast.success に表示するメッセージを安定化（messageが無い場合はデフォルト文言）

## 背景 / 目的
CafeFormStateReturn で nearby を必須にしたことで、UseCafeFormState の戻り値との不整合が発生していたため修正。
APIレスポンスの型が確定できず data.message にアクセスできないため、実行時チェックで安全に扱うようにした。



https://github.com/ken512/WorkBrew/pull/21/changes/36726401fc500069bde9a500389e62014b54e79a
## **やったこと**
 Nearby Searchの半径を500mに変更
