### PR TITLE
座標管理をlatitude/longitudeへ移行し、Googleマップ表示ロジックを修正

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,7 +61,9 @@ model Cafe {
   seatAvailability       SeatAvailability?
   starRating             Int               
   comment                String
-  locationCoordinates    String
+  locationCoordinates    String?
+  latitude               Float?
+  longitude              Float?
   userId                 Int
   favorites              Favorite[]
   users                  Users             @relation(fields: [userId], references: [id])

--- a/src/app/_components/CafeDescription.tsx
+++ b/src/app/_components/CafeDescription.tsx
@@ -373,7 +373,7 @@ console.log("lat/lng", cafe?.latitude, cafe?.longitude);
             className="my-10 rounded-lg shadow-md h-[400px] w-full border border-blue-500"
           />
           <Script
-            src={`https://maps.googleapis.com/maps/api/js?key=${process.env.NEXT_PUBLIC_GOOGLE_MAP_API_KEY}`}
+            src={`https://maps.googleapis.com/maps/api/js?key=${process.env.NEXT_PUBLIC_GOOGLE_MAP_API_KEY}&libraries=marker`}
             onLoad={() => {
               if (cafe?.latitude != null && cafe?.longitude != null) {
                 initMap(setMap, [cafe]); // 配列にする

--- a/src/app/_components/CafeDescription.tsx
+++ b/src/app/_components/CafeDescription.tsx
@@ -85,18 +85,20 @@ export const CafeDescription: React.FC<UpdateHandlers> = ({
       setWifiAvailable(cafe.wifiAvailable);
     }
   }, [cafe]);
-
+  const cafeLocationCoordinate = cafe?.latitude != null && cafe?.longitude != null;
   //クライアント側で使える状態になったら描画させる
   useEffect(() => {
     if (
       typeof window !== "undefined" &&
       window.google &&
       window.google.maps &&
-      cafe.locationCoordinates
+      cafeLocationCoordinate
     ) {
       initMap(setMap, [cafe]); // 1件だけでも配列に
     }
-  }, [cafe.locationCoordinates, cafe]);
+  }, [cafeLocationCoordinate, cafe]);
+  console.log("cafe raw", cafe);
+console.log("lat/lng", cafe?.latitude, cafe?.longitude);
   console.log("地図", cafe.locationCoordinates);
 
   const handleDelete = async (e: React.FormEvent) => {
@@ -373,7 +375,7 @@ export const CafeDescription: React.FC<UpdateHandlers> = ({
           <Script
             src={`https://maps.googleapis.com/maps/api/js?key=${process.env.NEXT_PUBLIC_GOOGLE_MAP_API_KEY}`}
             onLoad={() => {
-              if (cafe.locationCoordinates) {
+              if (cafe?.latitude != null && cafe?.longitude != null) {
                 initMap(setMap, [cafe]); // 配列にする
               }
             }} //Google Maps API のスクリプトが完全に読み込まれた後に実行(undefinedにならないために)

--- a/src/app/_types/Cafe.ts
+++ b/src/app/_types/Cafe.ts
@@ -1,5 +1,5 @@
 import { WifiSpeed,  WifiStability, SeatAvailability } from "@prisma/client";
-
+import { Coordinate } from "../admin/cafe_submission_form/types/coordinate";
 export type Cafe = {
   id: number;
   cafeName: string;
@@ -22,7 +22,7 @@ export type Cafe = {
   seatAvailability: SeatAvailability;
   starRating: number | null;
   comment: string; 
-  locationCoordinates: string;
+  locationCoordinates: Coordinate | null;
   createdAt: Date;
   updatedAt: Date;
   userId: number;

--- a/src/app/_types/CafePostFormType.ts
+++ b/src/app/_types/CafePostFormType.ts
@@ -1,5 +1,5 @@
 import { WifiSpeed,  WifiStability, SeatAvailability } from "@prisma/client";
-
+import { Coordinate } from "../admin/cafe_submission_form/types/coordinate";
 export type CafePostFormProps = {
   cafeName: string;
   setCafeName:(cafeName: string) => void;
@@ -29,10 +29,10 @@ export type CafePostFormProps = {
   setPowerOutlets: (powerOutlets: boolean) => void;
   seatAvailability: SeatAvailability;
   setSeatAvailability: (seatAvailability: SeatAvailability) => void;
-  starRating: number;
+  starRating: number | null;
   setStarRating:(starRating: number) => void;
   comment: string;
   setComment: (comment: string) => void;
-  locationCoordinates: string;
-  setLocationCoordinates: (locationCoordinates: string) => void;
+  locationCoordinates: Coordinate | null;
+  setLocationCoordinates: (locationCoordinates: Coordinate) => void;
 }

--- a/src/app/admin/_components/CafePostForm.tsx
+++ b/src/app/admin/_components/CafePostForm.tsx
@@ -30,7 +30,7 @@ const fetchGeocode = async (url: string) => {
     throw new Error("住所の緯度・経度を取得できませんでした");
   }
   const loc = data.results[0].geometry.location;
-  return `${loc.lat}, ${loc.lng}`;
+    return { latitude: loc.lat, longitude: loc.lng };
 };
 
 export const CafePostForm: React.FC<CafeFormStateReturn> = ({
@@ -70,7 +70,7 @@ export const CafePostForm: React.FC<CafeFormStateReturn> = ({
       onSuccess: (coordinates) => {
         setFormState((prevState) => ({
           ...prevState,
-          locationCoordinates: coordinates,
+          locationCoordinates: { latitude: coordinates.latitude, longitude: coordinates.longitude },
         }));
       },
     },
@@ -108,6 +108,7 @@ export const CafePostForm: React.FC<CafeFormStateReturn> = ({
       setIsSubmitting(false);
     }
   };
+  console.log("送信直前データ:", formState);
 
   const validateForm = async () => {
     const tempErrors: FormErrorsType = {};
@@ -242,15 +243,23 @@ export const CafePostForm: React.FC<CafeFormStateReturn> = ({
   };
 
   // 候補選択時の更新処理
-  const handleSelectCandidate = (c: PlaceCandidate) => {
-    setFormState((prev) => ({
-      ...prev,
-      cafeName: c.cafeName,
-      storeAddress: c.storeAddress,
-      locationCoordinates: `${c.locationCoordinates.latitude}, ${c.locationCoordinates.longitude}`,
-    }));
-    setIsOpenCandidates(false);
-  };
+const handleSelectCandidate = (c: PlaceCandidate) => {
+  setFormState((prev) => ({
+    ...prev,
+    cafeName: c.cafeName,
+    storeAddress: c.storeAddress,
+    locationCoordinates: c.locationCoordinates
+      ? {
+          latitude: c.locationCoordinates.latitude,
+          longitude: c.locationCoordinates.longitude,
+        }
+      : null,
+  }));
+  console.log("candidate", c);
+console.log("candidate.locationCoordinates", c.locationCoordinates);
+  setIsOpenCandidates(false);
+};
+
 
   const { params } = nearby;
   // 現在地取得後、お店住所欄をフォーカスすることで現在地から周辺情報を一覧させる
@@ -304,7 +313,7 @@ export const CafePostForm: React.FC<CafeFormStateReturn> = ({
               type="text"
               name={name}
               id={name}
-              value={String(formState[name as keyof typeof formState] ?? "")}
+              value={String(formState[name as keyof typeof formState] ?? null)}
               placeholder={placeholder}
               onChange={onChange}
               required={required}

--- a/src/app/admin/_hooks/useCafeFormState.ts
+++ b/src/app/admin/_hooks/useCafeFormState.ts
@@ -4,6 +4,7 @@ import { CafeFormStateProps } from "../_types/CafeFormStateProps";
 import { CafeFormStateReturn } from "../_types/CafeFormStateReturn";
 import { useNearbySearchParams } from "../cafe_submission_form/hooks/useNearbySearchParams";
 import { useCurrentLocation } from "../cafe_submission_form/hooks/useCurrentLocation";
+
 export const UseCafeFormState = (): CafeFormStateReturn => {
   const cafeState: CafeFormStateProps = {
     cafeName: "",
@@ -19,9 +20,9 @@ export const UseCafeFormState = (): CafeFormStateReturn => {
     wifiStability: null,
     powerOutlets: null,
     seatAvailability: null,
-    starRating: 0,
+    starRating: null,
     comment: "",
-    locationCoordinates: "",
+    locationCoordinates: null,
     
   };
 

--- a/src/app/admin/_types/CafeFormStateProps.ts
+++ b/src/app/admin/_types/CafeFormStateProps.ts
@@ -1,4 +1,5 @@
 import { WifiSpeed,  WifiStability, SeatAvailability } from "@prisma/client";
+import { Coordinate } from "../cafe_submission_form/types/coordinate";
 
 // カフェの状態管理用の型定義
 export type CafeFormStateProps = {
@@ -6,7 +7,7 @@ export type CafeFormStateProps = {
   thumbnailImage: string;
   area: string;
   storeAddress: string;
-  businessHours: string,
+  businessHours: "",
   closingDays: string;
   cafeUrl: string;
   menuOrdered: string;
@@ -15,7 +16,7 @@ export type CafeFormStateProps = {
   wifiStability?: WifiStability | null;
   powerOutlets: boolean | null;
   seatAvailability: SeatAvailability | null;
-  starRating: number;
+  starRating: number | null;
   comment: string;
-  locationCoordinates: string;
+  locationCoordinates: Coordinate | null;
 }

--- a/src/app/admin/_utils/initMap.ts
+++ b/src/app/admin/_utils/initMap.ts
@@ -1,54 +1,51 @@
 "use client";
+
 //Googleマップを表示させるページ(/cafe_submission_form/[id])にインポートして活用
 export const initMap = async (
   setMap: React.Dispatch<React.SetStateAction<google.maps.Map | null>>,
   cafeList: {
-    locationCoordinates: string;
+    latitude: number | null;
+    longitude: number | null;
     storeAddress: string;
     cafeName: string;
-  }[] //投稿データ
+  }[], //投稿データ
 ) => {
   const mapElement = document.getElementById("map"); // マップを表示させるHTMLの箱
-  const [latStr, lngStr] = cafeList[0].locationCoordinates.split(",");
-  const lat = parseFloat(latStr.trim());
-  const lng = parseFloat(lngStr.trim());
-  
-  /*googleマップの初期化(Google マップを画面に描画する)*/
-  if (mapElement) {
-    const map = new google.maps.Map(mapElement, {
-      zoom: 16, //地図のズームレベル
-      mapTypeId: google.maps.MapTypeId.ROADMAP, //種類（表示スタイル）を指定するプロパティ
-      maxZoom: 25, //地図のズームレベルの最大値
-      center: { lat, lng }, // ピン立ての位置を中心にする
-    });
-    console.log("Map element:", mapElement);
-    setMap(map);
-
-    {
-      /*各カフェのピン（マーカー）を立てる*/
-    }
-    cafeList.forEach((cafe) => {
-      const [latStr, lngStr] = cafe.locationCoordinates.split(",");
-      const lat = parseFloat(latStr.trim());
-      const lng = parseFloat(lngStr.trim());
-      
-      
-      const marker = new google.maps.Marker({
-        position: { lat, lng },
-        map,
-        title: `${cafe.cafeName} - ${cafe.storeAddress}`,
-      });
-      //マーカークリック時に、情報をポップアップ表示させる(スマホ対応)
-      const infoWindow = new google.maps.InfoWindow({
-        content: `<div>${cafe.cafeName}<br/>${cafe.storeAddress}</div>`,
-      });
-      marker.addListener("click", () => {
-        infoWindow.open(map, marker);
-      });
-    });
-
-    console.log("Google Maps Object:", google.maps);
-  } else {
-    console.error("Google Maps API is not available");
+  if (!mapElement) {
+    console.error("Map element not found");
+    return;
   }
+
+  // 中心点にできる座標を持つカフェを探す
+  const first = cafeList.find((c) => c.latitude != null && c.longitude != null);
+  if (!first) {
+    console.error("No valid coordinates in cafeList", cafeList);
+    return;
+  }
+  const map = new google.maps.Map(mapElement, {
+    zoom: 16,
+    mapTypeId: google.maps.MapTypeId.ROADMAP,
+    maxZoom: 25,
+    center: { lat: first.latitude!, lng: first.longitude! },
+  });
+
+  setMap(map);
+
+  cafeList.forEach((cafe) => {
+    if (cafe.latitude == null || cafe.longitude == null) return;
+
+    const marker = new google.maps.Marker({
+      position: { lat: cafe.latitude, lng: cafe.longitude },
+      map,
+      title: `${cafe.cafeName} - ${cafe.storeAddress}`,
+    });
+    console.log("cafeList raw:", cafeList);
+    const infoWindow = new google.maps.InfoWindow({
+      content: `<div>${cafe.cafeName}<br/>${cafe.storeAddress}</div>`,
+    });
+
+    marker.addListener("click", () => {
+      infoWindow.open(map, marker);
+    });
+  });
 };

--- a/src/app/admin/_utils/initMap.ts
+++ b/src/app/admin/_utils/initMap.ts
@@ -24,17 +24,21 @@ export const initMap = async (
   }
   const map = new google.maps.Map(mapElement, {
     zoom: 16,
-    mapTypeId: google.maps.MapTypeId.ROADMAP,
+    mapId: process.env.NEXT_PUBLIC_GOOGLE_MAP_ID,
     maxZoom: 25,
     center: { lat: first.latitude!, lng: first.longitude! },
   });
 
   setMap(map);
 
+  const { AdvancedMarkerElement } = (await google.maps.importLibrary(
+  "marker",
+)) as google.maps.MarkerLibrary;
+
   cafeList.forEach((cafe) => {
     if (cafe.latitude == null || cafe.longitude == null) return;
 
-    const marker = new google.maps.Marker({
+    const marker = new AdvancedMarkerElement({
       position: { lat: cafe.latitude, lng: cafe.longitude },
       map,
       title: `${cafe.cafeName} - ${cafe.storeAddress}`,

--- a/src/app/admin/cafe_submission_form/types/placeCandidate.ts
+++ b/src/app/admin/cafe_submission_form/types/placeCandidate.ts
@@ -4,7 +4,7 @@ export type PlaceCandidate = {
   placeId?: number;
   cafeName: string;
   storeAddress: string;
-  locationCoordinates: Coordinate;
+  locationCoordinates: Coordinate | null;
   primaryType?: string;
   types: string[];
 };

--- a/src/app/api/admin/cafe_submission_form/[id]/route.ts
+++ b/src/app/api/admin/cafe_submission_form/[id]/route.ts
@@ -6,15 +6,13 @@ import { Cafe } from "@/app/_types/Cafe";
 const prisma = new PrismaClient();
 
 export const GET = async (request: NextRequest) => {
-  
-
   try {
     const { currentUser, error } = await getCurrentUser(request);
 
-  if (error || !currentUser) {
-    return NextResponse.json({ message: "Unauthorized" }, { status: 400 });
-  }
-  
+    if (error || !currentUser) {
+      return NextResponse.json({ message: "Unauthorized" }, { status: 400 });
+    }
+
     const cafes = await prisma.cafe.findMany({
       where: {
         users: {
@@ -50,7 +48,7 @@ export const PUT = async (request: NextRequest) => {
     // ユーザーの取得
     const user = await prisma.users.findUnique({
       where: { supabaseUserId: currentUser.user.id },
-      select: { id: true }
+      select: { id: true },
     });
 
     if (!user) {
@@ -77,16 +75,16 @@ export const PUT = async (request: NextRequest) => {
     }: Cafe = await request.json();
 
     // URLからカフェIDを取得
-    const cafeId = parseInt(request.url.split('/').pop() || '');
+    const cafeId = parseInt(request.url.split("/").pop() || "");
 
     if (starRating === null) {
       throw new Error("Invalid input data");
     }
 
     const updatedCafe = await prisma.cafe.update({
-      where: { 
+      where: {
         id: cafeId,
-        userId: user.id  // このユーザーのカフェのみ更新可能
+        userId: user.id, // このユーザーのカフェのみ更新可能
       },
       data: {
         cafeName,
@@ -104,19 +102,20 @@ export const PUT = async (request: NextRequest) => {
         seatAvailability,
         starRating,
         comment,
-        locationCoordinates,
+        latitude: locationCoordinates?.latitude ?? null,
+        longitude: locationCoordinates?.longitude ?? null,
       },
     });
 
     return NextResponse.json(
       { status: "更新が成功しました", cafe: updatedCafe },
-      { status: 200 }
+      { status: 200 },
     );
   } catch (error) {
     if (error instanceof Error) {
       return NextResponse.json(
         { status: "更新が失敗しました", message: error.message },
-        { status: 400 }
+        { status: 400 },
       );
     }
   }

--- a/src/app/api/admin/cafe_submission_form/route.ts
+++ b/src/app/api/admin/cafe_submission_form/route.ts
@@ -6,7 +6,6 @@ import { NextRequest, NextResponse } from "next/server";
 const prisma = new PrismaClient();
 
 export const GET = async (request: NextRequest) => {
-
   try {
     const { currentUser, error } = await getCurrentUser(request);
 
@@ -15,7 +14,7 @@ export const GET = async (request: NextRequest) => {
     }
 
     const user = await prisma.users.findUnique({
-      where: { supabaseUserId: currentUser.user.id }, 
+      where: { supabaseUserId: currentUser.user.id },
       include: {
         cafes: {
           select: {
@@ -48,10 +47,12 @@ export const GET = async (request: NextRequest) => {
       },
     });
 
+    
+
     if (!user) {
       return NextResponse.json(
         { status: "Not Found", message: "ユーザー情報が見つかりません" },
-        { status: 400 }
+        { status: 400 },
       );
     }
     return NextResponse.json({ status: "OK", user }, { status: 200 });
@@ -83,9 +84,6 @@ export const POST = async (request: NextRequest) => {
       cafeName,
       area,
       storeAddress,
-      placeId,
-      primaryType,
-      types,
       businessHours,
       thumbnailImage,
       closingDays,
@@ -104,9 +102,6 @@ export const POST = async (request: NextRequest) => {
     if (
       !cafeName ||
       !storeAddress ||
-      !placeId||
-      !primaryType ||
-      !types ||
       starRating === null ||
       wifiAvailable === null ||
       powerOutlets === null ||
@@ -130,9 +125,6 @@ export const POST = async (request: NextRequest) => {
         cafeName,
         area,
         storeAddress,
-        placeId,
-        primaryType,
-        types,
         openingTime,
         closingHours,
         thumbnailImage,
@@ -146,7 +138,8 @@ export const POST = async (request: NextRequest) => {
         seatAvailability,
         starRating,
         comment,
-        locationCoordinates,
+        latitude: locationCoordinates?.latitude ?? null,
+        longitude: locationCoordinates?.longitude ?? null,
         userId: user.id,
       },
     });


### PR DESCRIPTION

## 背景https://github.com/ken512/WorkBrew/pull/22/changes/893576d78d627c630e891ce5c5712767714a19c9

Nearby Search機能追加に伴い、座標データの扱いを見直しました。
従来は "lat, lng" の文字列で管理していましたが、地図表示や将来的な距離検索を考慮し、緯度・経度を数値型で管理する設計へ変更。

## ■ 変更内容

- Prisma Cafe モデルに latitude / longitude を追加
- POST APIで座標を数値型で保存するよう修正
- Google Map 初期化処理を latitude/longitude ベースへ変更
- locationCoordinates 文字列依存のロジックを削除
- 座標取得処理（Geocode / Nearby）を型統一
- 不要なバリデーションチェックを整理

## ■ 修正理由

- 文字列型の座標は split / parseFloat 前提の実装となり、型の不整合が発生しやすかったため
- 将来的な距離検索・範囲検索への拡張を考慮
- 地図表示での undefined バグを解消するため





## やったことhttps://github.com/ken512/WorkBrew/pull/22/changes/90c31aca992015fcee49b7577a811b4b7e8df6aa
Google Mapsの非推奨/警告（Advanced Marker利用制限）に対応し、Map ID + marker library を追加して AdvancedMarkerElement を安定動作させた。


- AdvancedMarkerElement 利用のため marker ライブラリを読み込むように修正（libraries=marker / importLibrary("marker")）
- Map ID 未指定による警告を解消するため、地図初期化時に mapId を設定
- google.maps.Marker 依存から AdvancedMarkerElement へ切り替え
- InfoWindow の open を AdvancedMarker 向けに調整（open({ map, anchor }) 形式）

- マーカー生成前に座標の null ガードを追加し、undefined 由来の例外を防止

