### PR TITLE
ログイン直後にデフォルトのユーザーアカウントを自動作成するよう修正

### DIFF
--- a/src/app/_components/CafeDescription.tsx
+++ b/src/app/_components/CafeDescription.tsx
@@ -199,7 +199,7 @@ console.log("lat/lng", cafe?.latitude, cafe?.longitude);
   // ローディング中の表示
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center min-h-screen">
+      <div className="bg-tan-300 flex items-center justify-center min-h-screen">
         <p className="text-lg font-semibold">
           ☕️ コーヒーを淹れています... お待ちください
         </p>

--- a/src/app/_components/GuestLoginButton.tsx
+++ b/src/app/_components/GuestLoginButton.tsx
@@ -4,13 +4,14 @@ import { useRouter } from "next/navigation";
 import { supabase } from "@/_utils/supabase";
 import { Button } from "../admin/_components/Button";
 import toast, { Toaster } from "react-hot-toast";
+import api from "@/_utils/api";
 import "../globals.css";
 
 export const GuestLoginButton: React.FC = () => {
   const router = useRouter();
   const handleGuestLogin = async () => {
     //ゲスト用アカウントでログイン
-    const {error} = await supabase.auth.signInWithPassword({
+    const { error } = await supabase.auth.signInWithPassword({
       email: process.env.NEXT_PUBLIC_GUEST_EMAIL!,
       password: process.env.NEXT_PUBLIC_GUEST_PASSWORD!,
     });
@@ -20,26 +21,32 @@ export const GuestLoginButton: React.FC = () => {
       console.error("ゲストログイン失敗:", error.message);
       toast.error("ゲストログインに失敗しました");
       return;
-    };
-  
+    }
+
     //セッション確認
-    const {data: {session}, error: sessionError} = await supabase.auth.getSession();
-    if(sessionError || !session) {
-      console.error("セッション取得失敗: ",sessionError?.message);
+    const {
+      data: { session },
+      error: sessionError,
+    } = await supabase.auth.getSession();
+    if (sessionError || !session) {
+      console.error("セッション取得失敗: ", sessionError?.message);
       toast.error("セッション取得に失敗しました！");
       return;
-    };
+    }
+
+    await api.post("/api/admin/user_account/init", {});
+
     toast.success("ゲストとしてログインしました");
-    router.push("/admin/home"); 
+    router.push("/admin/home");
     console.log("セッション", session.user.email);
   };
 
   return (
     <div>
-    <Button type="button" variant="secondary" onClick={handleGuestLogin}>
-      ゲストログイン
-    </Button>
-    <Toaster position="top-center" reverseOrder={false} />
+      <Button type="button" variant="secondary" onClick={handleGuestLogin}>
+        ゲストログイン
+      </Button>
+      <Toaster position="top-center" reverseOrder={false} />
     </div>
   );
 };

--- a/src/app/_components/Navigation/NavBar.tsx
+++ b/src/app/_components/Navigation/NavBar.tsx
@@ -68,7 +68,7 @@ export const NavBar:React.FC = () => {
                 使い方
               </a>
               <a 
-                href="#cafes" 
+                href="/cafe_post" 
                 className="text-gray-700 hover:text-[#d6b288] px-2 sm:px-3 py-2 text-sm lg:text-base font-medium"
               >
                 カフェ一覧

--- a/src/app/_components/NewsSection/NewsSection.tsx
+++ b/src/app/_components/NewsSection/NewsSection.tsx
@@ -6,6 +6,7 @@ interface NewsItem {
   publishDate: string;
   updateDate: string;
   title: string;
+  summary?: string;
   tags: string[];
 }
 
@@ -14,6 +15,13 @@ const newsItems: NewsItem[] = [
     publishDate: '2025/04/22',
     updateDate: '2025/04/22',
     title: 'WorkBrewをリリースしました!!',
+    tags: ['Webアプリ関連']
+  },
+  {
+    publishDate: '2026/02/27',
+    updateDate: '2026/02/27',
+    title: '新機能をリリースしました!!',
+    summary: '店舗住所の入力補助機能を追加し、入力の手間を減らしました。',
     tags: ['Webアプリ関連']
   },
 ];
@@ -40,6 +48,9 @@ export const NewsSection: React.FC = () => {
               </div>
               <h3 className="text-lg font-medium mb-2">
                 {item.title}
+              </h3>
+              <h3 className="text-lg font-medium mb-2">
+                {item.summary}
               </h3>
               <div className="flex flex-wrap gap-2">
                 {item.tags.map((tag, tagIndex) => (

--- a/src/app/admin/_components/CafePostForm.tsx
+++ b/src/app/admin/_components/CafePostForm.tsx
@@ -279,6 +279,7 @@ console.log("candidate.locationCoordinates", c.locationCoordinates);
     try {
       setIsLoadingCandidates(true);
       const listCandidate = await fetchNearbyCandidates(params);
+      console.log("listCandidate: ", listCandidate);
       setCandidates(listCandidate);
       setIsConditionPanelOpen(true);
       setIsOpenCandidates(true);

--- a/src/app/admin/_components/HeaderAdminBase.tsx
+++ b/src/app/admin/_components/HeaderAdminBase.tsx
@@ -21,7 +21,7 @@ export const HeaderAdminBase = ({ href }: HeaderProps) => {
    // ローディング中の表示
     if (isLoading) {
       return (
-        <div className="flex items-center justify-center min-h-screen">
+        <div className="bg-tan-300 flex items-center justify-center min-h-screen">
           <p className="text-lg font-semibold">
             ☕️ コーヒーを淹れています... お待ちください
           </p>

--- a/src/app/admin/cafe_favorites/page.tsx
+++ b/src/app/admin/cafe_favorites/page.tsx
@@ -25,7 +25,7 @@ const CafeFavoriteList: React.FC = () => {
   // ローディング中の表示
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center min-h-screen">
+      <div className=" bg-tan-300 flex items-center justify-center min-h-screen">
         <p className="text-lg font-semibold">
           ☕️ コーヒーを淹れています... お待ちください
         </p>

--- a/src/app/admin/cafe_submission_form/_components/CandidateDropdown.tsx
+++ b/src/app/admin/cafe_submission_form/_components/CandidateDropdown.tsx
@@ -18,7 +18,7 @@ export const CandidateDropdown = ({
   return (
     <div className="mt-2 rounded-3xl border bg-white shadow">
       {loading ? (
-        <div className="p-4 text-sm text-black">
+        <div className="bg-tan-300 p-4 text-sm text-black">
           ☕️ コーヒーを淹れています... お待ちください
         </div>
       ): candidates.length === 0 ? (

--- a/src/app/admin/home/page.tsx
+++ b/src/app/admin/home/page.tsx
@@ -34,7 +34,7 @@ const Home: React.FC = () => {
   // ローディング中の表示
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center min-h-screen">
+      <div className="flex items-center justify-center min-h-screen bg-tan-300">
         <p className="text-lg font-semibold">
           ☕️ コーヒーを淹れています... お待ちください
         </p>

--- a/src/app/admin/user_account/page.tsx
+++ b/src/app/admin/user_account/page.tsx
@@ -38,7 +38,7 @@ const UserAccount: React.FC = () => {
       const data = await api.post("/api/admin/user_account", formState);
       // data がオブジェクトで、message というプロパティを持っていたら、それを文字列にして message に入れる。なければ undefined にする
       const message = typeof data === "object" && data !== null && "message" in data ? String((data as any).message): undefined;
-      toast.success(message || "ユーザー登録が完了しました！");
+      toast.success(message || "ユーザーアカウントが作成されました！");
     } catch (error) {
       console.error("ユーザー登録エラー:", error);
       toast.error(error instanceof Error ? error.message : "ユーザー登録に失敗しました。もう一度お試しください。");

--- a/src/app/api/admin/user_account/init/route.ts
+++ b/src/app/api/admin/user_account/init/route.ts
@@ -1,0 +1,43 @@
+import { getCurrentUser } from "@/_utils/supabase";
+import { PrismaClient } from "@prisma/client";
+import { NextRequest, NextResponse } from "next/server";
+
+const prisma = new PrismaClient();
+
+// ログイン済みユーザーに対応するUsersレコードが未作成の場合、デフォルトアカウントを作成するAPI
+export const POST = async (req: NextRequest) => {
+  const { currentUser, error} = await getCurrentUser(req);
+
+  if(error || !currentUser || !currentUser.user) {
+        return NextResponse.json({ message: "Unauthorized" }, { status: 400 });
+  }
+
+  try {
+
+    const existingUserAccount = await prisma.users.findUnique({
+      where: {supabaseUserId: currentUser.user.id},
+    });
+    if(existingUserAccount) {
+      return NextResponse.json( { 
+          status: "ERROR", 
+          message: "すでにアカウントが存在します" 
+        },
+        { status: 200 });
+    }
+
+        const defaultUserAccount = await prisma.users.create({
+      data: {
+        supabaseUserId: currentUser.user.id,
+        userName: `user_${currentUser.user.id.slice(0, 8)}`,
+        profileIcon: "",
+        biography: "",
+      }
+    })
+
+    return NextResponse.json({status: "OK", user: defaultUserAccount}, {status: 200});
+  } catch(error) {
+    if (error instanceof Error) {
+      return NextResponse.json({ status: error.message}, { status: 500});
+    }
+  }
+}

--- a/src/app/cafe_post/cafePostClient.tsx
+++ b/src/app/cafe_post/cafePostClient.tsx
@@ -44,7 +44,13 @@ const CafePostClient: React.FC = () => {
   };
 
   if (isLoading) {
-    return <p className="text-center">☕️ データ読み込み中です...</p>;
+    return (
+      <div className="bg-tan-300 flex items-center justify-center min-h-screen">
+        <p className="text-lg font-semibold">
+          ☕️ コーヒーを淹れています... お待ちください
+        </p>
+      </div>
+    );
   }
 
   if (error) {

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -8,6 +8,7 @@ import { HeaderPublic } from "../_components/HeaderPublic";
 import { FooterDefault } from "../_components/Footer/FooterDefault";
 import toast, { Toaster } from "react-hot-toast";
 import { Button } from "../admin/_components/Button";
+import api from "@/_utils/api";
 
 const Login: React.FC = () => {
   const [email, setEmail] = useState("");
@@ -30,6 +31,7 @@ const Login: React.FC = () => {
       // セッションが取得できているか確認
       const sessionCheck = await supabase.auth.getSession();
       if (sessionCheck.data.session) {
+        await api.post("/api/admin/user_account/init", {});
         toast.success("ログインに成功しました");
         router.replace("/admin/home");
       } else {


### PR DESCRIPTION
## 【要件】
Supabaseでサインアップ後にログインしたユーザーに対して、
PrismaのUsersテーブルにデフォルトのユーザーアカウントを自動作成する処理を追加しました。

これにより、ユーザーアカウント未作成状態でも
カフェ投稿などのUsersレコード依存機能が利用できるようになります。

##  やったこと
- /api/admin/user_account/init API を追加
- ログイン成功後にinit APIを呼び出す処理を追加
- Usersテーブルにレコードが存在しない場合のみデフォルトアカウントを作成
- NewsSectionの項目追加
- ローディング画面に bg-tan-300 を追加し、画面全体の背景色を他画面と揃えるように調整
